### PR TITLE
Gc 27 generate cli documentation

### DIFF
--- a/commands/cluster
+++ b/commands/cluster
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-. "$GRPL_WORKDIR/utils/common"
 . "$GRPL_WORKDIR/utils/help_menus"
 
 cli_help() {

--- a/commands/cluster
+++ b/commands/cluster
@@ -2,28 +2,19 @@
 
 set -e
 . "$GRPL_WORKDIR/utils/common"
+. "$GRPL_WORKDIR/utils/help_menus"
 
 cli_help() {
-  cli_name=${0##*/}
-  if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
-    extract_grapple_cli_version
-  fi
-  echo "
-$cli_name
-the grapple cli
-Version: $(cat $GRPL_WORKDIR/VERSION)
-https://grapple-solutions.com/
-
-Usage: $cli_name [command]
-
-Commands:
-  status     Cluster status
-  install    Cluster installation
-  create     Cluster creation
-  *          Help
-" >&2
+  grpl_cluster_cli_help
   exit 0
 }
+
+generate_web_doc() {
+  grpl_cluster_cli_help "web-doc"
+  exit 0
+}
+
+install_prerequisite
 
 case "$1" in
   status|s)
@@ -34,6 +25,9 @@ case "$1" in
     ;;
   create|c)
     "$GRPL_WORKDIR/commands/cluster_commands/create" $(echo $@ | sed 's,create,,g' | sed 's,c ,,') | tee -ia "$GRPL_WORKDIR/logs/cluster_create.log"
+    ;;
+  doc)
+    generate_web_doc
     ;;
   *)
     cli_help

--- a/commands/cluster
+++ b/commands/cluster
@@ -25,9 +25,6 @@ case "$1" in
   create|c)
     "$GRPL_WORKDIR/commands/cluster_commands/create" $(echo $@ | sed 's,create,,g' | sed 's,c ,,') | tee -ia "$GRPL_WORKDIR/logs/cluster_create.log"
     ;;
-  doc)
-    generate_web_doc
-    ;;
   *)
     cli_help
     ;;

--- a/commands/cluster_commands/create
+++ b/commands/cluster_commands/create
@@ -1,17 +1,13 @@
 #!/bin/bash
 set -e
-. "$GRPL_WORKDIR/utils/common"
+. "$GRPL_WORKDIR/utils/help_menus"
 
-cli_help_cluster_create() {
-  echo "
-Command: cluster create
-
-Usage: 
-  cluster create" >&2
+cli_help() {
+  grpl_cluster_create_cli_help
   exit 0
 }
 
-[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help_cluster_create
+[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help
 
 cli_log "cluster create BEGIN"
 

--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -65,7 +65,6 @@ NS=grpl-system
 awsregistry="p7h7z5g3"
 
 cli_log "cluster install BEGIN"
-install_prerequisite
 status_log $TYPE_INFO "Installation of grpl is in progress"
 
 

--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -3,62 +3,18 @@ set -e
 
 . "$GRPL_WORKDIR/utils/common"
 . "$GRPL_WORKDIR/utils/checks"
+. "$GRPL_WORKDIR/utils/help_menus"
 
 # --------------------------------- Functions ------------------------------------------
 
-
-
-cli_help_cluster_install() {
-  echo "
-Command: grpl cluster install
-
-Usage: 
-  cluster install
-
-Usage with params from cli: 
-  cluster install --params --<variable-name>=<variable value>
-  e.g cluster install --params --GRAPPLE_VERSION=0.2.1
-  OR
-  cluster install --params --<variable-name> <variable value>
-  e.g cluster install --params --GRAPPLE_VERSION 0.2.1
-
-Usage with params from configfile: 
-  cluster install --configfile <file-name>.json
-  e.g cluster install --configfile grpl-config.json
-
-Variables:
-  TARGET_PLATFORM=CIVO / Kubernetes / minikube
-
-  # general configurations
-  GRAPPLE_VERSION = version of the grapple deployment (e.g. '0.2.1')
-  AUTO_CONFIRM = false / true
-
-  # kubernetes related configurations
-  KUBE_CONTEXT = kubernetes context
-
-  # minikube related configurations
-  # no additional configurations
-
-  # CIVO related configurations
-  CIVO_REGION = Available CIVO regions (e.g. FRA1)
-  CIVO_CLUSTER = CIVO cluster
-  CIVO_CLUSTER_ID = CIVO cluster ID
-  CIVO_MASTER_IP = CIVO cluster master IP address
-  CIVO_EMAIL_ADDRESS = email address of your CIVO account
-
-" >&2
-# since we have restricted everything from stdout and sent it to log files
-# we won't be able to display the help menu with echo in terminal
-# so instead as a way around we'll use stderr to log the help menu on terminal
-# we could have used gum log but it didn't support \n
-# we whould have to write multiple log statements
+cli_help() {
+  grpl_cluster_install_cli_help
   exit 0
 }
 
-
 # --------------------------------- CODE ------------------------------------------
 
-[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help_cluster_install
+[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help
 
 
 NS=grpl-system

--- a/commands/cluster_commands/status
+++ b/commands/cluster_commands/status
@@ -1,17 +1,13 @@
 #!/bin/bash
 set -e
-. "$GRPL_WORKDIR/utils/common"
+. "$GRPL_WORKDIR/utils/help_menus"
 
-cli_help_cluster_status() {
-  echo "
-Command: cluster status
-
-Usage: 
-  cluster status"  >&2
+cli_help() {
+  grpl_cluster_status_cli_help
   exit 0
 }
 
-[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help_cluster_status
+[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help
 
 
 cli_log "cluster status BEGIN"

--- a/commands/doc
+++ b/commands/doc
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+. "$GRPL_WORKDIR/utils/help_menus"
+
+cli_help() {
+  grpl_cluster_status_cli_help
+  exit 0
+}
+
+[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help
+
+
+generate_web_doc

--- a/commands/example
+++ b/commands/example
@@ -2,25 +2,10 @@
 
 set -e
 . "$GRPL_WORKDIR/utils/common"
+. "$GRPL_WORKDIR/utils/help_menus"
 
 cli_help() {
-  cli_name=${0##*/}
-  if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
-    extract_grapple_cli_version
-  fi
-  echo "
-$cli_name
-the grapple cli
-Version: $(cat $GRPL_WORKDIR/VERSION)
-https://grapple-solutions.com/
-
-Usage: $cli_name [command]
-
-Commands:
-  status    status of example
-  deploy    deploy an example
-  *         Help
-" >&2
+  grpl_example_cli_help
   exit 0
 }
 

--- a/commands/example_commands/deploy
+++ b/commands/example_commands/deploy
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 . "$GRPL_WORKDIR/utils/common"
+. "$GRPL_WORKDIR/utils/help_menus"
 
 # NS=$(prompt_for_input_with_validation "Enter namespace: " "grapple-demo-namspace" "$non_empty_regex" "Namespace cannot be empty.") || exit $?
 # TESTNS=$(prompt_for_input_with_validation "Enter namespace for test case: " "grapple-test-demo-namspace: " "$non_empty_regex" "Namespace for test case cannot be empty.") || exit $?
@@ -10,21 +11,12 @@ TESTNS=grpl-dbfile
 TESTNSDB=grpl-db
 awsregistry="p7h7z5g3"
 
-cli_help_cluster_deploy() {
-  echo "
-Command: grpl example deploy
-
-Usage: 
-  example deploy
-
-Variables:
-  example     all / db / dbfile
-  EDITION = "grpl-basic-all" / "grpl-basic" / "grpl-basic-db" / "grpl-basic-dbfile"
-" >&2
+cli_help() {
+  grpl_example_status_cli_help
   exit 0
 }
 
-[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help_cluster_deploy
+[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help
 
 
 cli_log "example deploy BEGIN"

--- a/commands/example_commands/status
+++ b/commands/example_commands/status
@@ -1,17 +1,13 @@
 #!/bin/bash
 set -e
-. "$GRPL_WORKDIR/utils/common"
+. "$GRPL_WORKDIR/utils/help_menus"
 
-cli_help_cluster_status() {
-  echo "
-Command: example status
-
-Usage: 
-  example status" >&2
+cli_help() {
+  grpl_example_status_cli_help
   exit 0
 }
 
-[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help_cluster_status
+[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help
 
 
 cli_log "example status BEGIN"

--- a/commands/install
+++ b/commands/install
@@ -1,17 +1,14 @@
 #!/bin/bash
 set -e
 . "$GRPL_WORKDIR/utils/common"
+. "$GRPL_WORKDIR/utils/help_menus"
 
-cli_help_install() {
-  echo "
-Command: install
-
-Usage: 
-  install tool_name" >&2
+cli_help() {
+  grpl_install_cli_help
   exit 0
 }
 
-[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help_install
+[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help
 
 
 cli_log "install BEGIN"

--- a/commands/upgrade
+++ b/commands/upgrade
@@ -2,28 +2,15 @@
 
 set -e
 . "$GRPL_WORKDIR/utils/common"
+. "$GRPL_WORKDIR/utils/help_menus"
 install_prerequisite
 
-cli_upgrade_help() {
-  cli_name=${0##*/}
-  if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
-    extract_grapple_cli_version
-  fi
-  echo "
-$cli_name
-the grapple cli
-Version: $(cat $GRPL_WORKDIR/VERSION)
-https://grapple-solutions.com/
-
-Usage: $cli_name [command]
-
-Commands:
-  *         Help
-" >&2
+cli_help() {
+  grpl_upgrade_cli_help
   exit 0
 }
 
-[ "$1" = "help" ] || [ "$1" = "h" ] && cli_upgrade_help
+[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help
 
 info=$(brew info --json grapple-cli)
 

--- a/commands/version
+++ b/commands/version
@@ -2,27 +2,14 @@
 
 set -e
 . "$GRPL_WORKDIR/utils/common"
+. "$GRPL_WORKDIR/utils/help_menus"
 
-cli_version_help() {
-  cli_name=${0##*/}
-  if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
-    extract_grapple_cli_version
-  fi
-  echo "
-$cli_name
-the grapple cli
-Version: $(cat $GRPL_WORKDIR/VERSION)
-https://grapple-solutions.com/
-
-Usage: $cli_name [command]
-
-Commands:
-  *         Help
-"
+cli_help() {
+  grpl_version_cli_help
   exit 0
 }
 
-[ "$1" = "help" ] || [ "$1" = "h" ] && cli_version_help
+[ "$1" = "help" ] || [ "$1" = "h" ] && cli_help
 
 info=$(brew info --json grapple-cli)
 

--- a/grpl
+++ b/grpl
@@ -18,6 +18,7 @@ if ! ls $GRPL_WORKDIR | grep 'logs' >/dev/null 2>&1; then
   mkdir $GRPL_WORKDIR/logs 2>/dev/null | true
 fi
 
+
 case "$1" in
   install|i)
     "$GRPL_WORKDIR/commands/install" $(echo $@ | sed 's,install,,g' | sed 's,i ,,') | tee -ia "$GRPL_WORKDIR/logs/install.log" >/dev/null
@@ -33,6 +34,9 @@ case "$1" in
     ;;
   upgrade|u)
     "$GRPL_WORKDIR/commands/upgrade" $(echo $@ | sed 's,upgrade,,g' | sed 's,u ,,') | tee -ia "$GRPL_WORKDIR/logs/upgrade.log" >/dev/null
+    ;;
+  doc)
+    generate_web_doc
     ;;
   *)
     cli_help

--- a/grpl
+++ b/grpl
@@ -36,7 +36,7 @@ case "$1" in
     "$GRPL_WORKDIR/commands/upgrade" $(echo $@ | sed 's,upgrade,,g' | sed 's,u ,,') | tee -ia "$GRPL_WORKDIR/logs/upgrade.log" >/dev/null
     ;;
   doc)
-    generate_web_doc
+    generate_web_doc | tee -ia "$GRPL_WORKDIR/logs/doc.log" >/dev/null
     ;;
   *)
     cli_help

--- a/grpl
+++ b/grpl
@@ -35,8 +35,8 @@ case "$1" in
   upgrade|u)
     "$GRPL_WORKDIR/commands/upgrade" $(echo $@ | sed 's,upgrade,,g' | sed 's,u ,,') | tee -ia "$GRPL_WORKDIR/logs/upgrade.log" >/dev/null
     ;;
-  doc)
-    generate_web_doc | tee -ia "$GRPL_WORKDIR/logs/doc.log" >/dev/null
+  doc|d)
+    "$GRPL_WORKDIR/commands/doc" $(echo $@ | sed 's,doc,,g' | sed 's,d ,,') | tee -ia "$GRPL_WORKDIR/logs/doc.log" >/dev/null
     ;;
   *)
     cli_help

--- a/grpl
+++ b/grpl
@@ -4,26 +4,10 @@ export GRPL_WORKDIR=$(cd $(dirname $0) && pwd)
 export FULL_COMMAND="$0 $@"
 
 . "$GRPL_WORKDIR/utils/package_installer"
+. "$GRPL_WORKDIR/utils/help_menus"
 
 cli_help() {
-  cli_name=${0##*/}
-  if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
-    extract_grapple_cli_version
-  fi
-  echo "
-$cli_name
-the grapple cli
-Version: $(cat $GRPL_WORKDIR/VERSION)
-https://grapple-solutions.com/
-
-Usage: $cli_name [command]
-
-Commands:
-  install    Installation
-  cluster    Cluster commands
-  example    example commands
-  *          Help
-"
+  grpl_cli_help
   exit 0
 }
 

--- a/utils/constants
+++ b/utils/constants
@@ -31,3 +31,6 @@ NC='\033[0m' # No Color
 # input params type
 cli_params="--params"
 config_file_params="--configfile"
+
+# help menu types
+WEB_DOC="web-doc"

--- a/utils/help_menus
+++ b/utils/help_menus
@@ -59,9 +59,9 @@ grpl_cluster_cli_help() {
     fi
 
     type=$1
-    cli_name="cluster"
+    cli_name="grpl cluster"
     if [ "$type" == $WEB_DOC ]; then
-        cli_name="= cluster"
+        cli_name="= grpl cluster"
     fi
     menu="
 $cli_name
@@ -72,7 +72,7 @@ Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
 
-Usage: cluster [command]
+Usage: grpl cluster [command]
 
 Commands:
 
@@ -104,9 +104,9 @@ grpl_example_cli_help() {
     fi
 
     type=$1
-    cli_name="example"
+    cli_name="grpl example"
     if [ "$type" == $WEB_DOC ]; then
-        cli_name="= example"
+        cli_name="= grpl example"
     fi
     menu="
 $cli_name
@@ -117,7 +117,7 @@ Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
 
-Usage: example [command]
+Usage: grpl example [command]
 
 Commands:
 
@@ -148,9 +148,9 @@ grpl_install_cli_help() {
     fi
 
     type=$1
-    cli_name="install"
+    cli_name="grpl install"
     if [ "$type" == $WEB_DOC ]; then
-        cli_name="= install"
+        cli_name="= grpl install"
     fi
     menu="
 $cli_name
@@ -161,7 +161,7 @@ Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
 
-Usage: install [command]
+Usage: grpl install [command]
 
 " 
     if [ "$type" == $WEB_DOC ]; then
@@ -181,9 +181,9 @@ grpl_example_cli_help() {
     fi
 
     type=$1
-    cli_name="upgrade"
+    cli_name="grpl upgrade"
     if [ "$type" == $WEB_DOC ]; then
-        cli_name="= upgrade"
+        cli_name="= grpl upgrade"
     fi
     menu="
 $cli_name
@@ -194,7 +194,7 @@ Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
 
-Usage: upgrade [command]
+Usage: grpl upgrade [command]
 
 Commands:
 
@@ -224,9 +224,9 @@ grpl_version_cli_help() {
     fi
 
     type=$1
-    cli_name="version"
+    cli_name="grpl version"
     if [ "$type" == $WEB_DOC ]; then
-        cli_name="= version"
+        cli_name="= grpl version"
     fi
     menu="
 $cli_name
@@ -237,7 +237,7 @@ Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
 
-Usage: version [command]
+Usage: grpl version [command]
 
 Commands:
 
@@ -258,3 +258,252 @@ Examples:
         echo "$menu"  >&2
     fi
 }
+
+
+
+grpl_cluster_create_cli_help() {
+
+    if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
+      extract_grapple_cli_version
+    fi
+
+    type=$1
+    cli_name="grpl cluster create"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="= grpl cluster create"
+    fi
+    menu="
+$cli_name
+
+the grapple cli
+
+Version: $(cat $GRPL_WORKDIR/VERSION)
+
+https://grapple-solutions.com/
+
+Usage: grpl create [command]
+
+Commands:
+
+    h or help     Help menu
+    *             to create cluster
+    
+Examples:    
+
+    grpl c c h    or    grpl cluster create help
+    grpl c c *    or    grpl cluster create *
+"
+
+    if [ "$type" == $WEB_DOC ]; then
+        echo "$menu" > "$GRPL_WORKDIR/cluster-create-help-menu.adoc"
+        asciidoctor "$GRPL_WORKDIR/cluster-create-help-menu.adoc"
+        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/cluster-create-help-menu.html to view the doc"
+    else
+        echo "$menu"  >&2
+    fi
+}
+
+
+grpl_cluster_install_cli_help() {
+
+    if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
+      extract_grapple_cli_version
+    fi
+
+    type=$1
+    cli_name="grpl cluster install"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="= grpl cluster install"
+    fi
+    menu="
+$cli_name
+
+the grapple cli
+
+Version: $(cat $GRPL_WORKDIR/VERSION)
+
+https://grapple-solutions.com/
+
+Usage: 
+  grpl cluster install
+
+Usage with params from cli: 
+  grpl cluster install --params --<variable-name>=<variable value>
+  e.g cluster install --params --GRAPPLE_VERSION=0.2.1
+  OR
+  cluster install --params --<variable-name> <variable value>
+  e.g grpl cluster install --params --GRAPPLE_VERSION 0.2.1
+
+Usage with params from configfile: 
+  grpl cluster install --configfile <file-name>.json
+  e.g grpl cluster install --configfile grpl-config.json
+
+Command: grpl cluster install
+
+Variables:
+  TARGET_PLATFORM=CIVO / Kubernetes / minikube
+
+  # general configurations
+  GRAPPLE_VERSION = version of the grapple deployment (e.g. '0.2.1')
+  AUTO_CONFIRM = false / true
+
+  # kubernetes related configurations
+  KUBE_CONTEXT = kubernetes context
+
+  # minikube related configurations
+  # no additional configurations
+
+  # CIVO related configurations
+  CIVO_REGION = Available CIVO regions (e.g. FRA1)
+  CIVO_CLUSTER = CIVO cluster
+  CIVO_CLUSTER_ID = CIVO cluster ID
+  CIVO_MASTER_IP = CIVO cluster master IP address
+  CIVO_EMAIL_ADDRESS = email address of your CIVO account
+
+" 
+
+    if [ "$type" == $WEB_DOC ]; then
+        echo "$menu" > "$GRPL_WORKDIR/cluster-install-help-menu.adoc"
+        asciidoctor "$GRPL_WORKDIR/cluster-install-help-menu.adoc"
+        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/cluster-install-help-menu.html to view the doc"
+    else
+        echo "$menu"  >&2
+    fi
+}
+
+
+grpl_cluster_status_cli_help() {
+
+    if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
+      extract_grapple_cli_version
+    fi
+
+    type=$1
+    cli_name="grpl cluster status"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="= grpl cluster status"
+    fi
+    menu="
+$cli_name
+
+the grapple cli
+
+Version: $(cat $GRPL_WORKDIR/VERSION)
+
+https://grapple-solutions.com/
+
+Usage: grpl cluster status [command]
+
+Commands:
+
+    h or help     Help menu
+    *             to get cluster status
+    
+Examples:    
+
+    grpl c s h    or    grpl cluster status help
+    grpl c s *    or    grpl cluster status *
+"
+
+    if [ "$type" == $WEB_DOC ]; then
+        echo "$menu" > "$GRPL_WORKDIR/cluster-status-help-menu.adoc"
+        asciidoctor "$GRPL_WORKDIR/cluster-status-help-menu.adoc"
+        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/cluster-status-help-menu.html to view the doc"
+    else
+        echo "$menu"  >&2
+    fi
+}
+
+
+
+grpl_example_deploy_cli_help() {
+
+    if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
+      extract_grapple_cli_version
+    fi
+
+    type=$1
+    cli_name="grpl cluster status"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="= grpl cluster status"
+    fi
+    menu="
+$cli_name
+
+the grapple cli
+
+Version: $(cat $GRPL_WORKDIR/VERSION)
+
+https://grapple-solutions.com/
+
+Usage: grpl example deploy [command]
+
+Commands:
+
+    h or help     Help menu
+    *             to get deploy example test-cases
+    
+Examples:    
+
+    grpl e d h    or    grpl example deploy help
+    grpl e d *    or    grpl example deploy *
+
+Variables:
+  example     all / db / dbfile
+  EDITION = "grpl-basic-all" / "grpl-basic" / "grpl-basic-db" / "grpl-basic-dbfile"
+" 
+
+    if [ "$type" == $WEB_DOC ]; then
+        echo "$menu" > "$GRPL_WORKDIR/cluster-status-help-menu.adoc"
+        asciidoctor "$GRPL_WORKDIR/cluster-status-help-menu.adoc"
+        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/cluster-status-help-menu.html to view the doc"
+    else
+        echo "$menu"  >&2
+    fi
+}
+
+
+
+grpl_example_status_cli_help() {
+
+    if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
+      extract_grapple_cli_version
+    fi
+
+    type=$1
+    cli_name="grpl example status"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="= grpl example status"
+    fi
+    menu="
+$cli_name
+
+the grapple cli
+
+Version: $(cat $GRPL_WORKDIR/VERSION)
+
+https://grapple-solutions.com/
+
+Usage: grpl example status [command]
+
+Commands:
+
+    h or help     Help menu
+    *             to get example status
+    
+Examples:    
+
+    grpl e s h    or    grpl example status help
+    grpl e s *    or    grpl example status *
+"
+
+    if [ "$type" == $WEB_DOC ]; then
+        echo "$menu" > "$GRPL_WORKDIR/example-status-help-menu.adoc"
+        asciidoctor "$GRPL_WORKDIR/example-status-help-menu.adoc"
+        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/example-status-help-menu.html to view the doc"
+    else
+        echo "$menu"  >&2
+    fi
+}
+
+

--- a/utils/help_menus
+++ b/utils/help_menus
@@ -1,6 +1,12 @@
 #!/bin/bash
 
+. "$GRPL_WORKDIR/utils/common"
+
 grpl_cluster_cli_help() {
+
+    if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
+      extract_grapple_cli_version
+    fi
     
     type=$0
     cli_name="cluster"

--- a/utils/help_menus
+++ b/utils/help_menus
@@ -2,6 +2,40 @@
 
 . "$GRPL_WORKDIR/utils/common"
 
+generate_web_doc() {
+
+    grpl_cli_help $WEB_DOC
+    grpl_cluster_cli_help $WEB_DOC
+    grpl_example_cli_help $WEB_DOC
+    grpl_install_cli_help $WEB_DOC
+    grpl_upgrade_cli_help $WEB_DOC
+    grpl_version_cli_help $WEB_DOC
+     doc="
+= grpl cli Documentation
+:toc: 
+
+== Introduction
+
+the grapple cli
+
+Version: $(cat $GRPL_WORKDIR/VERSION)
+
+https://grapple-solutions.com/[grapple solution^]
+
+
+$grpl_doc
+$grpl_cluster_doc
+$grpl_example_doc
+$grpl_install_doc
+$grpl_upgrade_doc
+$grpl_version_doc
+"
+echo "$doc" > "$GRPL_WORKDIR/grpl-web-doc.adoc"
+        asciidoctor "$GRPL_WORKDIR/grpl-web-doc.adoc"
+        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/grpl-web-doc.html to view the grpl documentation"
+        
+}
+
 grpl_cli_help() {
 
     if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
@@ -10,19 +44,24 @@ grpl_cli_help() {
 
     type=$1
     cli_name="grpl"
-    if [ "$type" == $WEB_DOC ]; then
-        cli_name="= grpl"
-    fi
-    menu="
-$cli_name
-
+    meta="
 the grapple cli
 
 Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
+"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="== grpl"
+        meta=""
+    fi
 
-Usage: grpl [command]
+    grpl_doc="
+$cli_name
+$meta
+Usage: 
+
+    grpl [command]
 
 Commands:
 
@@ -43,11 +82,9 @@ Examples:
 
 "
     if [ "$type" == $WEB_DOC ]; then
-        echo "$menu" > "$GRPL_WORKDIR/grpl-help-menu.adoc"
-        asciidoctor "$GRPL_WORKDIR/grpl-help-menu.adoc"
-        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/grpl-help-menu.html to view the doc"
+        return 0
     else
-        echo "$menu"  >&2
+        echo "$grpl_doc"  >&2
     fi
 }
 
@@ -60,19 +97,25 @@ grpl_cluster_cli_help() {
 
     type=$1
     cli_name="grpl cluster"
-    if [ "$type" == $WEB_DOC ]; then
-        cli_name="= grpl cluster"
-    fi
-    menu="
-$cli_name
-
+    meta="
 the grapple cli
 
 Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
+"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="== grpl cluster"
+        meta=""
+    fi
 
-Usage: grpl cluster [command]
+    grpl_cluster_doc="
+$cli_name
+$meta
+
+Usage: 
+
+    grpl cluster [command]
 
 Commands:
 
@@ -89,11 +132,9 @@ Examples:
 
 "
     if [ "$type" == $WEB_DOC ]; then
-        echo "$menu" > "$GRPL_WORKDIR/cluster-help-menu.adoc"
-        asciidoctor "$GRPL_WORKDIR/cluster-help-menu.adoc"
-        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/cluster-help-menu.html to view the doc"
+        return 0
     else
-        echo "$menu"  >&2
+        echo "$grpl_cluster_doc"  >&2
     fi
 }
 
@@ -105,19 +146,25 @@ grpl_example_cli_help() {
 
     type=$1
     cli_name="grpl example"
-    if [ "$type" == $WEB_DOC ]; then
-        cli_name="= grpl example"
-    fi
-    menu="
-$cli_name
-
+    meta="
 the grapple cli
 
 Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
+"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="== grpl example"
+        meta=""
+    fi
 
-Usage: grpl example [command]
+    grpl_example_doc="
+$cli_name
+$meta
+
+Usage: 
+
+    grpl example [command]
 
 Commands:
 
@@ -132,11 +179,9 @@ Examples:
 
 " 
     if [ "$type" == $WEB_DOC ]; then
-        echo "$menu" > "$GRPL_WORKDIR/example-help-menu.adoc"
-        asciidoctor "$GRPL_WORKDIR/example-help-menu.adoc"
-        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/example-help-menu.html to view the doc"
+        return 0
     else
-        echo "$menu"  >&2
+        echo "$grpl_example_doc"  >&2
     fi
 }
 
@@ -149,27 +194,31 @@ grpl_install_cli_help() {
 
     type=$1
     cli_name="grpl install"
-    if [ "$type" == $WEB_DOC ]; then
-        cli_name="= grpl install"
-    fi
-    menu="
-$cli_name
-
+    meta="
 the grapple cli
 
 Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
+"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="== grpl install"
+        meta=""
+    fi
 
-Usage: grpl install [command]
+    grpl_install_doc="
+$cli_name
+$meta
+
+Usage: 
+
+    grpl install [command]
 
 " 
     if [ "$type" == $WEB_DOC ]; then
-        echo "$menu" > "$GRPL_WORKDIR/install-help-menu.adoc"
-        asciidoctor "$GRPL_WORKDIR/install-help-menu.adoc"
-        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/install-help-menu.html to view the doc"
+        return 0
     else
-        echo "$menu"  >&2
+        echo "$grpl_install_doc"  >&2
     fi
 }
 
@@ -182,19 +231,25 @@ grpl_upgrade_cli_help() {
 
     type=$1
     cli_name="grpl upgrade"
-    if [ "$type" == $WEB_DOC ]; then
-        cli_name="= grpl upgrade"
-    fi
-    menu="
-$cli_name
-
+    meta="
 the grapple cli
 
 Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
+"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="== grpl upgrade"
+        meta=""
+    fi
 
-Usage: grpl upgrade [command]
+    grpl_upgrade_doc="
+$cli_name
+$meta
+
+Usage: 
+    
+    grpl upgrade [command]
 
 Commands:
 
@@ -208,11 +263,9 @@ Examples:
 
 " 
     if [ "$type" == $WEB_DOC ]; then
-        echo "$menu" > "$GRPL_WORKDIR/upgrade-help-menu.adoc"
-        asciidoctor "$GRPL_WORKDIR/upgrade-help-menu.adoc"
-        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/upgrade-help-menu.html to view the doc"
+        return 0
     else
-        echo "$menu"  >&2
+        echo "$grpl_upgrade_doc"  >&2
     fi
 }
 
@@ -225,19 +278,25 @@ grpl_version_cli_help() {
 
     type=$1
     cli_name="grpl version"
-    if [ "$type" == $WEB_DOC ]; then
-        cli_name="= grpl version"
-    fi
-    menu="
-$cli_name
-
+    meta="
 the grapple cli
 
 Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
+"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="== grpl version"
+        meta=""
+    fi
 
-Usage: grpl version [command]
+    grpl_version_doc="
+$cli_name
+$meta
+
+Usage: 
+
+    grpl version [command]
 
 Commands:
 
@@ -251,11 +310,9 @@ Examples:
 
 " 
     if [ "$type" == $WEB_DOC ]; then
-        echo "$menu" > "$GRPL_WORKDIR/version-help-menu.adoc"
-        asciidoctor "$GRPL_WORKDIR/version-help-menu.adoc"
-        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/version-help-menu.html to view the doc"
+        return 0
     else
-        echo "$menu"  >&2
+        echo "$grpl_version_doc"  >&2
     fi
 }
 
@@ -270,7 +327,7 @@ grpl_cluster_create_cli_help() {
     type=$1
     cli_name="grpl cluster create"
     if [ "$type" == $WEB_DOC ]; then
-        cli_name="= grpl cluster create"
+        cli_name="== grpl cluster create"
     fi
     menu="
 $cli_name
@@ -313,7 +370,7 @@ grpl_cluster_install_cli_help() {
     type=$1
     cli_name="grpl cluster install"
     if [ "$type" == $WEB_DOC ]; then
-        cli_name="= grpl cluster install"
+        cli_name="== grpl cluster install"
     fi
     menu="
 $cli_name
@@ -381,7 +438,7 @@ grpl_cluster_status_cli_help() {
     type=$1
     cli_name="grpl cluster status"
     if [ "$type" == $WEB_DOC ]; then
-        cli_name="= grpl cluster status"
+        cli_name="== grpl cluster status"
     fi
     menu="
 $cli_name
@@ -425,7 +482,7 @@ grpl_example_deploy_cli_help() {
     type=$1
     cli_name="grpl cluster status"
     if [ "$type" == $WEB_DOC ]; then
-        cli_name="= grpl cluster status"
+        cli_name="== grpl cluster status"
     fi
     menu="
 $cli_name
@@ -473,7 +530,7 @@ grpl_example_status_cli_help() {
     type=$1
     cli_name="grpl example status"
     if [ "$type" == $WEB_DOC ]; then
-        cli_name="= grpl example status"
+        cli_name="== grpl example status"
     fi
     menu="
 $cli_name

--- a/utils/help_menus
+++ b/utils/help_menus
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+grpl_cluster_cli_help() {
+    
+    type=$0
+    cli_name="cluster"
+    if [ "$type" == "web-doc" ]; then
+        cli_name="--cluster"
+    fi
+    menu="
+$cli_name
+
+the grapple cli
+
+Version: $(cat $GRPL_WORKDIR/VERSION)
+
+https://grapple-solutions.com/
+
+Usage: cluster [command]
+
+Commands:
+
+    s or status     Cluster status
+    i or install    Cluster installation
+    c or create     Cluster creation
+    *          Help
+    
+Examples:    
+
+    grpl c s    or    grpl cluster status
+    grpl c i    or    grpl cluster install      
+    grpl c c    or    grpl cluster create  
+
+"
+    if [ "$type" == "doc" ]; then
+        echo "$menu" > "$GRPL_WORKDIR/cluster-help-menu.adoc"
+        asciidoctor "$GRPL_WORKDIR/cluster-help-menu.adoc"
+    else
+        echo "$menu"  >&2
+    fi
+}

--- a/utils/help_menus
+++ b/utils/help_menus
@@ -3,7 +3,7 @@
 . "$GRPL_WORKDIR/utils/common"
 
 generate_web_doc() {
-    
+
     install_prerequisite
     check_and_install_asciidoc
 
@@ -35,7 +35,7 @@ Version: $(cat $GRPL_WORKDIR/VERSION)
 https://grapple-solutions.com/[grapple solution^]
 
 
-$grpl_doc
+$grpl_cli_doc
 $grpl_cluster_doc
 $grpl_example_doc
 $grpl_install_doc
@@ -52,6 +52,55 @@ echo "$doc" > "$GRPL_WORKDIR/grpl-web-doc.adoc"
         status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/grpl-web-doc.html to view the grpl documentation"
         
 }
+
+grpl_web_doc_cli_help() {
+
+    if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
+      extract_grapple_cli_version
+    fi
+
+    type=$1
+    cli_name="grpl doc"
+    meta="
+the grapple cli
+
+Version: $(cat $GRPL_WORKDIR/VERSION)
+
+https://grapple-solutions.com/
+"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="== grpl doc"
+        meta=""
+    fi
+
+    grpl_doc="
+$cli_name
+$meta
+
+Usage: 
+
+    grpl doc [command]
+
+Commands:
+
+    h or help     Help menu
+    *             to generate web documentation
+    
+Examples:
+
+    grpl d h    or    grpl doc help
+    grpl d *    or    grpl doc *
+"
+
+    if [ "$type" == $WEB_DOC ]; then
+        return 0
+    else
+        echo "$grpl_doc"  >&2
+    fi
+}
+
+
+
 
 grpl_cli_help() {
 
@@ -73,7 +122,7 @@ https://grapple-solutions.com/
         meta=""
     fi
 
-    grpl_doc="
+    grpl_cli_doc="
 $cli_name
 $meta
 Usage: 
@@ -91,18 +140,18 @@ Commands:
     
 Examples:    
 
-    grpl i <commands>    or    grpl install <commands>
-    grpl c <commands>    or    grpl cluster <commands>     
-    grpl e <commands>    or    grpl example <commands>     
-    grpl v <commands>    or    grpl version <commands>     
-    grpl u <commands>    or    grpl upgrade <commands> 
+    grpl i [commands]    or    grpl install [commands]
+    grpl c [commands]    or    grpl cluster [commands]     
+    grpl e [commands]    or    grpl example [commands]     
+    grpl v [commands]    or    grpl version [commands]     
+    grpl u [commands]    or    grpl upgrade [commands] 
     grpl *
 
 "
     if [ "$type" == $WEB_DOC ]; then
         return 0
     else
-        echo "$grpl_doc"  >&2
+        echo "$grpl_cli_doc"  >&2
     fi
 }
 

--- a/utils/help_menus
+++ b/utils/help_menus
@@ -7,11 +7,11 @@ grpl_cluster_cli_help() {
     if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
       extract_grapple_cli_version
     fi
-    
-    type=$0
+
+    type=$1
     cli_name="cluster"
     if [ "$type" == "web-doc" ]; then
-        cli_name="--cluster"
+        cli_name="= cluster"
     fi
     menu="
 $cli_name
@@ -38,9 +38,10 @@ Examples:
     grpl c c    or    grpl cluster create  
 
 "
-    if [ "$type" == "doc" ]; then
+    if [ "$type" == "web-doc" ]; then
         echo "$menu" > "$GRPL_WORKDIR/cluster-help-menu.adoc"
         asciidoctor "$GRPL_WORKDIR/cluster-help-menu.adoc"
+        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/cluster-help-menu.html to view the doc"
     else
         echo "$menu"  >&2
     fi

--- a/utils/help_menus
+++ b/utils/help_menus
@@ -2,6 +2,56 @@
 
 . "$GRPL_WORKDIR/utils/common"
 
+grpl_cli_help() {
+
+    if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
+      extract_grapple_cli_version
+    fi
+
+    type=$1
+    cli_name="grpl"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="= grpl"
+    fi
+    menu="
+$cli_name
+
+the grapple cli
+
+Version: $(cat $GRPL_WORKDIR/VERSION)
+
+https://grapple-solutions.com/
+
+Usage: grpl [command]
+
+Commands:
+
+    i or install     Installation
+    c or cluster     Cluster commands
+    e or example     Example commands
+    v or version     List version
+    u or upgrade     Upgrade grpl
+    *                Help menu
+    
+Examples:    
+
+    grpl i <commands>    or    grpl install <commands>
+    grpl c <commands>    or    grpl cluster <commands>     
+    grpl e <commands>    or    grpl example <commands>     
+    grpl v <commands>    or    grpl version <commands>     
+    grpl u <commands>    or    grpl upgrade <commands> 
+
+"
+    if [ "$type" == $WEB_DOC ]; then
+        echo "$menu" > "$GRPL_WORKDIR/grpl-help-menu.adoc"
+        asciidoctor "$GRPL_WORKDIR/grpl-help-menu.adoc"
+        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/grpl-help-menu.html to view the doc"
+    else
+        echo "$menu"  >&2
+    fi
+}
+
+
 grpl_cluster_cli_help() {
 
     if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
@@ -10,7 +60,7 @@ grpl_cluster_cli_help() {
 
     type=$1
     cli_name="cluster"
-    if [ "$type" == "web-doc" ]; then
+    if [ "$type" == $WEB_DOC ]; then
         cli_name="= cluster"
     fi
     menu="
@@ -29,7 +79,7 @@ Commands:
     s or status     Cluster status
     i or install    Cluster installation
     c or create     Cluster creation
-    *          Help
+    *               Help menu
     
 Examples:    
 
@@ -38,10 +88,172 @@ Examples:
     grpl c c    or    grpl cluster create  
 
 "
-    if [ "$type" == "web-doc" ]; then
+    if [ "$type" == $WEB_DOC ]; then
         echo "$menu" > "$GRPL_WORKDIR/cluster-help-menu.adoc"
         asciidoctor "$GRPL_WORKDIR/cluster-help-menu.adoc"
         status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/cluster-help-menu.html to view the doc"
+    else
+        echo "$menu"  >&2
+    fi
+}
+
+grpl_example_cli_help() {
+
+    if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
+      extract_grapple_cli_version
+    fi
+
+    type=$1
+    cli_name="example"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="= example"
+    fi
+    menu="
+$cli_name
+
+the grapple cli
+
+Version: $(cat $GRPL_WORKDIR/VERSION)
+
+https://grapple-solutions.com/
+
+Usage: example [command]
+
+Commands:
+
+    s or status     status of example
+    d or deploy     deploy an example
+    *               Help menu
+    
+Examples:    
+
+    grpl e s    or    grpl example status
+    grpl e d    or    grpl example deploy
+
+" 
+    if [ "$type" == $WEB_DOC ]; then
+        echo "$menu" > "$GRPL_WORKDIR/example-help-menu.adoc"
+        asciidoctor "$GRPL_WORKDIR/example-help-menu.adoc"
+        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/example-help-menu.html to view the doc"
+    else
+        echo "$menu"  >&2
+    fi
+}
+
+
+grpl_install_cli_help() {
+
+    if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
+      extract_grapple_cli_version
+    fi
+
+    type=$1
+    cli_name="install"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="= install"
+    fi
+    menu="
+$cli_name
+
+the grapple cli
+
+Version: $(cat $GRPL_WORKDIR/VERSION)
+
+https://grapple-solutions.com/
+
+Usage: install [command]
+
+" 
+    if [ "$type" == $WEB_DOC ]; then
+        echo "$menu" > "$GRPL_WORKDIR/install-help-menu.adoc"
+        asciidoctor "$GRPL_WORKDIR/install-help-menu.adoc"
+        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/install-help-menu.html to view the doc"
+    else
+        echo "$menu"  >&2
+    fi
+}
+
+
+grpl_example_cli_help() {
+
+    if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
+      extract_grapple_cli_version
+    fi
+
+    type=$1
+    cli_name="upgrade"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="= upgrade"
+    fi
+    menu="
+$cli_name
+
+the grapple cli
+
+Version: $(cat $GRPL_WORKDIR/VERSION)
+
+https://grapple-solutions.com/
+
+Usage: upgrade [command]
+
+Commands:
+
+    h or help     Help menu
+    *             to upgrade
+    
+Examples:    
+
+    grpl u h    or    grpl upgrade help
+    grpl u *    or    grpl upgrade *
+
+" 
+    if [ "$type" == $WEB_DOC ]; then
+        echo "$menu" > "$GRPL_WORKDIR/upgrade-help-menu.adoc"
+        asciidoctor "$GRPL_WORKDIR/upgrade-help-menu.adoc"
+        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/upgrade-help-menu.html to view the doc"
+    else
+        echo "$menu"  >&2
+    fi
+}
+
+
+grpl_version_cli_help() {
+
+    if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
+      extract_grapple_cli_version
+    fi
+
+    type=$1
+    cli_name="version"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="= version"
+    fi
+    menu="
+$cli_name
+
+the grapple cli
+
+Version: $(cat $GRPL_WORKDIR/VERSION)
+
+https://grapple-solutions.com/
+
+Usage: version [command]
+
+Commands:
+
+    h or help     Help menu
+    *             to get version details
+    
+Examples:    
+
+    grpl v h    or    grpl version help
+    grpl v *    or    grpl version *
+
+" 
+    if [ "$type" == $WEB_DOC ]; then
+        echo "$menu" > "$GRPL_WORKDIR/version-help-menu.adoc"
+        asciidoctor "$GRPL_WORKDIR/version-help-menu.adoc"
+        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/version-help-menu.html to view the doc"
     else
         echo "$menu"  >&2
     fi

--- a/utils/help_menus
+++ b/utils/help_menus
@@ -174,7 +174,7 @@ Usage: grpl install [command]
 }
 
 
-grpl_example_cli_help() {
+grpl_upgrade_cli_help() {
 
     if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
       extract_grapple_cli_version

--- a/utils/help_menus
+++ b/utils/help_menus
@@ -10,6 +10,11 @@ generate_web_doc() {
     grpl_install_cli_help $WEB_DOC
     grpl_upgrade_cli_help $WEB_DOC
     grpl_version_cli_help $WEB_DOC
+    grpl_cluster_create_cli_help $WEB_DOC
+    grpl_cluster_install_cli_help $WEB_DOC
+    grpl_cluster_status_cli_help $WEB_DOC
+    grpl_example_deploy_cli_help $WEB_DOC
+    grpl_example_status_cli_help $WEB_DOC
      doc="
 = grpl cli Documentation
 :toc: 
@@ -29,6 +34,11 @@ $grpl_example_doc
 $grpl_install_doc
 $grpl_upgrade_doc
 $grpl_version_doc
+$grpl_cluster_create_doc
+$grpl_cluster_install_doc
+$grpl_cluster_status_doc
+$grpl_example_deploy_doc
+$grpl_example_status_doc
 "
 echo "$doc" > "$GRPL_WORKDIR/grpl-web-doc.adoc"
         asciidoctor "$GRPL_WORKDIR/grpl-web-doc.adoc"
@@ -79,6 +89,7 @@ Examples:
     grpl e <commands>    or    grpl example <commands>     
     grpl v <commands>    or    grpl version <commands>     
     grpl u <commands>    or    grpl upgrade <commands> 
+    grpl *
 
 "
     if [ "$type" == $WEB_DOC ]; then
@@ -129,6 +140,7 @@ Examples:
     grpl c s    or    grpl cluster status
     grpl c i    or    grpl cluster install      
     grpl c c    or    grpl cluster create  
+    grpl c *    or    grpl cluster *
 
 "
     if [ "$type" == $WEB_DOC ]; then
@@ -176,6 +188,7 @@ Examples:
 
     grpl e s    or    grpl example status
     grpl e d    or    grpl example deploy
+    grpl e *    or    grpl example *
 
 " 
     if [ "$type" == $WEB_DOC ]; then
@@ -326,19 +339,25 @@ grpl_cluster_create_cli_help() {
 
     type=$1
     cli_name="grpl cluster create"
-    if [ "$type" == $WEB_DOC ]; then
-        cli_name="== grpl cluster create"
-    fi
-    menu="
-$cli_name
-
+    meta="
 the grapple cli
 
 Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
+"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="== grpl cluster create"
+        meta=""
+    fi
 
-Usage: grpl create [command]
+    grpl_cluster_create_doc="
+$cli_name
+$meta
+
+Usage: 
+
+    grpl cluster create [command]
 
 Commands:
 
@@ -352,11 +371,9 @@ Examples:
 "
 
     if [ "$type" == $WEB_DOC ]; then
-        echo "$menu" > "$GRPL_WORKDIR/cluster-create-help-menu.adoc"
-        asciidoctor "$GRPL_WORKDIR/cluster-create-help-menu.adoc"
-        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/cluster-create-help-menu.html to view the doc"
+        return 0
     else
-        echo "$menu"  >&2
+        echo "$grpl_cluster_create_doc"  >&2
     fi
 }
 
@@ -369,47 +386,60 @@ grpl_cluster_install_cli_help() {
 
     type=$1
     cli_name="grpl cluster install"
-    if [ "$type" == $WEB_DOC ]; then
-        cli_name="== grpl cluster install"
-    fi
-    menu="
-$cli_name
-
+    meta="
 the grapple cli
 
 Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
+"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="== grpl cluster install"
+        meta=""
+    fi
+
+    grpl_cluster_install_doc="
+$cli_name
+$meta
 
 Usage: 
-  grpl cluster install
+
+  grpl cluster install [command]
 
 Usage with params from cli: 
+
   grpl cluster install --params --<variable-name>=<variable value>
-  e.g cluster install --params --GRAPPLE_VERSION=0.2.1
+  e.g grpl cluster install --params --GRAPPLE_VERSION=0.2.1
   OR
-  cluster install --params --<variable-name> <variable value>
+  grpl cluster install --params --<variable-name> <variable value>
   e.g grpl cluster install --params --GRAPPLE_VERSION 0.2.1
 
 Usage with params from configfile: 
+
   grpl cluster install --configfile <file-name>.json
   e.g grpl cluster install --configfile grpl-config.json
 
-Command: grpl cluster install
+Commands:
+
+    h or help     Help menu
+    *             to install cluster
+    
+Examples:    
+
+    grpl c i h    or    grpl cluster install help
+    grpl c i *    or    grpl cluster install *
+
 
 Variables:
+
   TARGET_PLATFORM=CIVO / Kubernetes / minikube
-
   # general configurations
-  GRAPPLE_VERSION = version of the grapple deployment (e.g. '0.2.1')
-  AUTO_CONFIRM = false / true
-
+  GRAPPLE_VERSION = version of the grapple deployment (e.g. '0.2.0' or '0.2.1')
+  AUTO_CONFIRM = 'false' / 'true'
   # kubernetes related configurations
   KUBE_CONTEXT = kubernetes context
-
   # minikube related configurations
   # no additional configurations
-
   # CIVO related configurations
   CIVO_REGION = Available CIVO regions (e.g. FRA1)
   CIVO_CLUSTER = CIVO cluster
@@ -420,11 +450,9 @@ Variables:
 " 
 
     if [ "$type" == $WEB_DOC ]; then
-        echo "$menu" > "$GRPL_WORKDIR/cluster-install-help-menu.adoc"
-        asciidoctor "$GRPL_WORKDIR/cluster-install-help-menu.adoc"
-        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/cluster-install-help-menu.html to view the doc"
+        return 0
     else
-        echo "$menu"  >&2
+        echo "$grpl_cluster_install_doc"  >&2
     fi
 }
 
@@ -437,19 +465,25 @@ grpl_cluster_status_cli_help() {
 
     type=$1
     cli_name="grpl cluster status"
-    if [ "$type" == $WEB_DOC ]; then
-        cli_name="== grpl cluster status"
-    fi
-    menu="
-$cli_name
-
+    meta="
 the grapple cli
 
 Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
+"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="== grpl cluster status"
+        meta=""
+    fi
 
-Usage: grpl cluster status [command]
+    grpl_cluster_status_doc="
+$cli_name
+$meta
+
+Usage: 
+
+    grpl cluster status [command]
 
 Commands:
 
@@ -463,11 +497,9 @@ Examples:
 "
 
     if [ "$type" == $WEB_DOC ]; then
-        echo "$menu" > "$GRPL_WORKDIR/cluster-status-help-menu.adoc"
-        asciidoctor "$GRPL_WORKDIR/cluster-status-help-menu.adoc"
-        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/cluster-status-help-menu.html to view the doc"
+        return 0
     else
-        echo "$menu"  >&2
+        echo "$grpl_cluster_status_doc"  >&2
     fi
 }
 
@@ -480,20 +512,26 @@ grpl_example_deploy_cli_help() {
     fi
 
     type=$1
-    cli_name="grpl cluster status"
-    if [ "$type" == $WEB_DOC ]; then
-        cli_name="== grpl cluster status"
-    fi
-    menu="
-$cli_name
-
+    cli_name="grpl example deploy"
+    meta="
 the grapple cli
 
 Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
+"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="== grpl example deploy"
+        meta=""
+    fi
 
-Usage: grpl example deploy [command]
+    grpl_example_deploy_doc="
+$cli_name
+$meta
+
+Usage: 
+
+    grpl example deploy [command]
 
 Commands:
 
@@ -506,16 +544,15 @@ Examples:
     grpl e d *    or    grpl example deploy *
 
 Variables:
-  example     all / db / dbfile
+
+  example   all / db / dbfile
   EDITION = "grpl-basic-all" / "grpl-basic" / "grpl-basic-db" / "grpl-basic-dbfile"
 " 
 
     if [ "$type" == $WEB_DOC ]; then
-        echo "$menu" > "$GRPL_WORKDIR/cluster-status-help-menu.adoc"
-        asciidoctor "$GRPL_WORKDIR/cluster-status-help-menu.adoc"
-        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/cluster-status-help-menu.html to view the doc"
+        return 0
     else
-        echo "$menu"  >&2
+        echo "$grpl_example_deploy_doc"  >&2
     fi
 }
 
@@ -529,19 +566,25 @@ grpl_example_status_cli_help() {
 
     type=$1
     cli_name="grpl example status"
-    if [ "$type" == $WEB_DOC ]; then
-        cli_name="== grpl example status"
-    fi
-    menu="
-$cli_name
-
+    meta="
 the grapple cli
 
 Version: $(cat $GRPL_WORKDIR/VERSION)
 
 https://grapple-solutions.com/
+"
+    if [ "$type" == $WEB_DOC ]; then
+        cli_name="== grpl example status"
+        meta=""
+    fi
 
-Usage: grpl example status [command]
+    grpl_example_status_doc="
+$cli_name
+$meta
+
+Usage: 
+
+    grpl example status [command]
 
 Commands:
 
@@ -555,11 +598,9 @@ Examples:
 "
 
     if [ "$type" == $WEB_DOC ]; then
-        echo "$menu" > "$GRPL_WORKDIR/example-status-help-menu.adoc"
-        asciidoctor "$GRPL_WORKDIR/example-status-help-menu.adoc"
-        status_log $TYPE_INFO "please visit file://$GRPL_WORKDIR/example-status-help-menu.html to view the doc"
+        return 0
     else
-        echo "$menu"  >&2
+        echo "$grpl_example_status_doc"  >&2
     fi
 }
 

--- a/utils/help_menus
+++ b/utils/help_menus
@@ -3,6 +3,13 @@
 . "$GRPL_WORKDIR/utils/common"
 
 generate_web_doc() {
+    
+    install_prerequisite
+    check_and_install_asciidoc
+
+    if ! grep -q "." "$GRPL_WORKDIR/VERSION" >/dev/null 2>&1; then 
+      extract_grapple_cli_version
+    fi
 
     grpl_cli_help $WEB_DOC
     grpl_cluster_cli_help $WEB_DOC

--- a/utils/package_installer
+++ b/utils/package_installer
@@ -156,6 +156,36 @@ check_and_install_kubeblocks() {
     
 }
 
+check_and_install_asciidoc() {
+
+    # checks for checking and installing minikube
+    if ! asciidoctor --version  >/dev/null 2>&1; then
+        echo "asciidoctor cli is required"
+        echo "installing asciidoctor cli..."
+        if [ "${OS}" == "mac" ]; then
+            gum spin --title "asciidoctor is not installed, now installing asciidoctor" --show-output -- brew install asciidoctor
+        elif [ "${OS}" == "gnu" ]; then
+            status_log $TYPE_INFO "going to refresh snap"
+            sudo snap refresh 2>&1
+            gum spin --title "ruby is not installed, now installing ruby" --show-output -- sudo snap install ruby --classic
+            gum spin --title "asciidoctor is not installed, now installing asciidoctor" --show-output -- gem install asciidoctor
+            exe_file_path=$(gem which asciidoctor)
+            extracted_version=$(echo "$string" | awk -F '/' '{print $6}')
+            asciidoc_template_path="~/.gem/gems/{}/bin"
+            asciidoc_path=$(echo "$asciidoc_template_path" | sed 's/{}/asciidoctor-2.0.22/')
+            export PATH="$asciidoc_path:$PATH"
+        else
+            errMsg="Failed to install asciidoctor, OS ${OS} not supported at the moment"
+            echo $errMsg
+            status_log $TYPE_ERROR $errMsg
+            exit 1
+        fi
+    fi
+
+    # extract_minikube_cli_version
+
+}
+
 
 extract_helm_cli_version(){
 
@@ -286,3 +316,4 @@ extract_grapple_cli_version(){
     fi
 
 }
+


### PR DESCRIPTION
**Description**

1. Added command **grpl doc | d** to generate web-doc for all commands
2. Added a msg in the cli to give the web-doc link (this is temporary)

**Test case**

https://github.com/grapple-solutions/grapple-cli/assets/163305499/95c19ee2-e049-4133-9891-69a527365ba1


**NOTE : if you are running this command from inside linuxbrew container then you'll have to mount volume at
/home/linuxbrew/.linuxbrew/Cellar/grapple-cli/0.2.22/libexec/grpl-web-doc.html to make file available at your machine and then access it from there.**