### PR TITLE
GC-42 resolved first comment

### DIFF
--- a/utils/common
+++ b/utils/common
@@ -258,7 +258,6 @@ transform_crds_docs_into_web_docs_format() {
 
     local obj=""
     for obj in "${objects[@]}"; do
-    new_title="${base/.spec/}"
-      kubectl explain $base.$obj | transform_crds_docs_into_web_docs_format "$base.$obj" "=== $new_title.$obj"
+      kubectl explain $base.$obj | transform_crds_docs_into_web_docs_format "$base.$obj" "=== $base.$obj"
     done
 }


### PR DESCRIPTION
**Description**

1. Resolved 1st comment
2. The menu we have is actually a table of content, generated using a build-in command and it can't be collapsed. but if were to use  some sort or some custom stuff, we could make it happen. Also displaying non object fields in menu(table of content) isn't possible without adding a separate section for that in the doc below. We can fix 2nd point in the https://wolke7.atlassian.net/browse/GC-43

