### PR TITLE
Gc 57 grpl c i

### DIFF
--- a/commands/application_commands/init
+++ b/commands/application_commands/init
@@ -25,11 +25,11 @@ valid_args=(
 
 # check if values are already passed form terminal
 # if yes? then store then in the respective vars
-[ "$1" = "$cli_params" ] && extract_input_params_from_cli $valid_args "grpl a i h" $(echo "$@" | sed 's,help,,' | sed 's,h ,,' | sed 's,--params ,,')
+[ "$1" = "$cli_params" ] && shift && extract_input_params_from_cli $valid_args "grpl a i h" $(echo "$@" | sed 's,help,,' | sed 's,h ,,' | sed 's,--params ,,')
 
 # check if values are already passed form terminal through a file
 # if yes? then store then in the respective vars
-[ "$1" = "$config_file_params" ] && extract_input_params_from_file $valid_args "grpl a i h" $(echo "$@" | sed 's,help,,' | sed 's,h ,,' | sed 's,--configfile ,,')
+[ "$1" = "$config_file_params" ] && shift && extract_input_params_from_file $valid_args "grpl a i h" $(echo "$@" | sed 's,help,,' | sed 's,h ,,' | sed 's,--configfile ,,')
 
 #check if input from params is valid or not
 if [ "${PROJECT_NAME}" != "" ]; then 

--- a/commands/cluster
+++ b/commands/cluster
@@ -14,16 +14,17 @@ generate_web_doc() {
 }
 
 install_prerequisite
-
-case "$1" in
+command=$1
+shift
+case "$command" in
   status|s)
-    "$GRPL_WORKDIR/commands/cluster_commands/status" $(echo $@ | sed 's,status,,g' | sed 's,s ,,') | tee -ia "$GRPL_WORKDIR/logs/cluster_status.log"
+    "$GRPL_WORKDIR/commands/cluster_commands/status" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/cluster_status.log"
     ;;
   install|i)
-    "$GRPL_WORKDIR/commands/cluster_commands/install" $(echo $@ | sed 's,install,,g' | sed 's,i ,,') | tee -ia "$GRPL_WORKDIR/logs/cluster_install.log"
+    "$GRPL_WORKDIR/commands/cluster_commands/install" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/cluster_install.log"
     ;;
   create|c)
-    "$GRPL_WORKDIR/commands/cluster_commands/create" $(echo $@ | sed 's,create,,g' | sed 's,c ,,') | tee -ia "$GRPL_WORKDIR/logs/cluster_create.log"
+    "$GRPL_WORKDIR/commands/cluster_commands/create" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/cluster_create.log"
     ;;
   *)
     cli_help

--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -38,11 +38,12 @@ valid_args=(
   )
 # check if values are already passed form terminal
 # if yes? then store then in the respective vars
-[ "$1" = "$cli_params" ] && extract_input_params_from_cli $valid_args "grpl c i h" $(echo "$@" | sed 's,help,,' | sed 's,h ,,' | sed 's,--params ,,')
+
+[ "$1" = "$cli_params" ] && shift && extract_input_params_from_cli $valid_args "grpl c i h" $(echo "$@" | sed 's,help,,' | sed 's,h ,,' | sed 's,--params ,,')
 
 # check if values are already passed form terminal through a file
 # if yes? then store then in the respective vars
-[ "$1" = "$config_file_params" ] && extract_input_params_from_file $valid_args "grpl c i h" $(echo "$@" | sed 's,help,,' | sed 's,h ,,' | sed 's,--configfile ,,')
+[ "$1" = "$config_file_params" ] && shift && extract_input_params_from_file $valid_args "grpl c i h" $(echo "$@" | sed 's,help,,' | sed 's,h ,,' | sed 's,--configfile ,,')
 
 
 # verify install target platform

--- a/commands/example
+++ b/commands/example
@@ -9,12 +9,14 @@ cli_help() {
   exit 0
 }
 
-case "$1" in
+command=$1
+shift
+case "$command" in
   status|s)
-    "$GRPL_WORKDIR/commands/example_commands/status" $(echo $@ | sed 's,status,,g' | sed 's,s ,,') | tee -ia "$GRPL_WORKDIR/logs/example_status.log"
+    "$GRPL_WORKDIR/commands/example_commands/status" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/example_status.log"
     ;;
   deploy|d)
-    "$GRPL_WORKDIR/commands/example_commands/deploy" $(echo $@ | sed 's,deploy,,g' | sed 's,i ,,') | tee -ia "$GRPL_WORKDIR/logs/example_deploy.log"
+    "$GRPL_WORKDIR/commands/example_commands/deploy" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/example_deploy.log"
     ;;
   *)
     cli_help

--- a/commands/resource
+++ b/commands/resource
@@ -8,12 +8,14 @@ cli_help() {
   exit 0
 }
 
-case "$1" in
+command=$1
+shift
+case "$command" in
   deploy|d)
-    "$GRPL_WORKDIR/commands/resource_commands/deploy" $(echo $@ | sed 's,deploy,,g' | sed 's,d ,,') | tee -ia "$GRPL_WORKDIR/logs/resource_deploy.log"
+    "$GRPL_WORKDIR/commands/resource_commands/deploy" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/resource_deploy.log"
     ;;
   render|r)
-    "$GRPL_WORKDIR/commands/resource_commands/render" $(echo $@ | sed 's,render,,g' | sed 's,r ,,') | tee -ia "$GRPL_WORKDIR/logs/resource_render.log"
+    "$GRPL_WORKDIR/commands/resource_commands/render" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/resource_render.log"
     ;;
   *)
     cli_help

--- a/commands/resource_commands/deploy
+++ b/commands/resource_commands/deploy
@@ -512,11 +512,11 @@ valid_args=(
 
 # check if values are already passed form terminal
 # if yes? then store then in the respective vars
-[ "$1" = "$cli_params" ] && extract_input_params_from_cli $valid_args "grpl r d h" $(echo "$@" | sed 's,help,,' | sed 's,h ,,' | sed 's,--params ,,')
+[ "$1" = "$cli_params" ] && shift && extract_input_params_from_cli $valid_args "grpl r d h" $(echo "$@" | sed 's,help,,' | sed 's,h ,,' | sed 's,--params ,,')
 
 # check if values are already passed form terminal through a file
 # if yes? then store then in the respective vars
-[ "$1" = "$config_file_params" ] && extract_input_params_from_file $valid_args "grpl r d h" $(echo "$@" | sed 's,help,,' | sed 's,h ,,' | sed 's,--configfile ,,')
+[ "$1" = "$config_file_params" ] && shift && extract_input_params_from_file $valid_args "grpl r d h" $(echo "$@" | sed 's,help,,' | sed 's,h ,,' | sed 's,--configfile ,,')
 
 #check if input from params is valid or not
 is_correct_kubectl_context_provided $KUBECTL_CONTEXT

--- a/grpl
+++ b/grpl
@@ -18,31 +18,32 @@ if ! ls $GRPL_WORKDIR | grep 'logs' >/dev/null 2>&1; then
   mkdir $GRPL_WORKDIR/logs 2>/dev/null | true
 fi
 
-
-case "$1" in
+command=$1
+shift
+case "$command" in
   install|i)
-    "$GRPL_WORKDIR/commands/install" $(echo $@ | sed 's,install,,g' | sed 's,i ,,') | tee -ia "$GRPL_WORKDIR/logs/install.log" >/dev/null
+    "$GRPL_WORKDIR/commands/install" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/install.log" >/dev/null
     ;;
   cluster|c)
-    "$GRPL_WORKDIR/commands/cluster" $(echo $@ | sed 's,cluster,,g' | sed 's,c ,,') | tee -ia "$GRPL_WORKDIR/logs/cluster.log" >/dev/null
+    "$GRPL_WORKDIR/commands/cluster" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/cluster.log" >/dev/null
     ;;
   example|e)
-    "$GRPL_WORKDIR/commands/example" $(echo $@ | sed 's,example,,g' | sed 's,e ,,') | tee -ia "$GRPL_WORKDIR/logs/example.log" >/dev/null
+    "$GRPL_WORKDIR/commands/example" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/example.log" >/dev/null
     ;;
   version|v)
-    "$GRPL_WORKDIR/commands/version" $(echo $@ | sed 's,version,,g' | sed 's,v ,,') | tee -ia "$GRPL_WORKDIR/logs/version.log"
+    "$GRPL_WORKDIR/commands/version" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/version.log"
     ;;
   upgrade|u)
-    "$GRPL_WORKDIR/commands/upgrade" $(echo $@ | sed 's,upgrade,,g' | sed 's,u ,,') | tee -ia "$GRPL_WORKDIR/logs/upgrade.log" >/dev/null
+    "$GRPL_WORKDIR/commands/upgrade" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/upgrade.log" >/dev/null
     ;;
   application|app|a)
-    "$GRPL_WORKDIR/commands/application" $(echo $@ | sed 's,application,,g' | sed 's,app,,g' | sed 's,a ,,') | tee -ia "$GRPL_WORKDIR/logs/application.log" >/dev/null
+    "$GRPL_WORKDIR/commands/application" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/application.log" >/dev/null
     ;;
   doc|d)
-    "$GRPL_WORKDIR/commands/doc" $(echo $@ | sed 's,doc,,g' | sed 's,d ,,') | tee -ia "$GRPL_WORKDIR/logs/doc.log" >/dev/null
+    "$GRPL_WORKDIR/commands/doc" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/doc.log" >/dev/null
     ;;
   resource|r)
-    "$GRPL_WORKDIR/commands/resource" $(echo $@ | sed 's,resource,,g' | sed 's,r ,,') | tee -ia "$GRPL_WORKDIR/logs/resource.log" >/dev/null
+    "$GRPL_WORKDIR/commands/resource" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/resource.log" >/dev/null
     ;;
   *)
     cli_help

--- a/utils/common
+++ b/utils/common
@@ -146,6 +146,8 @@ extract_input_params_from_cli() {
   while [[ $# -gt 0 ]]; do
 
       arg1=$1
+      shift
+      
       # determine which method is used to pass cli params
       if [[ "$arg1" = *=* ]]; then
           
@@ -181,8 +183,6 @@ extract_input_params_from_cli() {
           fi
       fi
 
-
-      shift
 
   done
 

--- a/utils/common
+++ b/utils/common
@@ -138,6 +138,8 @@ extract_input_params_from_file() {
 
 extract_input_params_from_cli() {
 
+  cli_args=$@
+  status_log $TYPE_INFO "$cli_agrs"
   valid_args=$1
   shift
   help_menu_cmd=$1
@@ -146,9 +148,7 @@ extract_input_params_from_cli() {
   while [[ $# -gt 0 ]]; do
 
       arg1=$1
-      shift
-
-      # determin which method is used to pass cli params
+      # determine which method is used to pass cli params
       if [[ "$arg1" = *=* ]]; then
           
           config_param="${arg1#--}"
@@ -184,7 +184,7 @@ extract_input_params_from_cli() {
       fi
 
 
-
+      shift
 
   done
 

--- a/utils/common
+++ b/utils/common
@@ -138,8 +138,6 @@ extract_input_params_from_file() {
 
 extract_input_params_from_cli() {
 
-  cli_args=$@
-  status_log $TYPE_INFO "$cli_agrs"
   valid_args=$1
   shift
   help_menu_cmd=$1


### PR DESCRIPTION
**Description**
The issue with params was that, when we run 
`echo $@ | sed 's,install,,g' | sed 's,i ,,'`
is used to replace first instance if "i " with empty string.
so if we used grpl cluster install as command, then it does remove install from the cli args but it also removes any instance of "i "
in the cli agrs, e.g if any arg ends with "i " then it would removes that, and that was causing that problem.
now instead of using **sed** to remove/trim the args, we used **shift**

**Testcase**
![Screenshot from 2024-06-24 08-59-57](https://github.com/grapple-solutions/grapple-cli/assets/163305499/7e0f8cc1-b687-4992-b252-5c9ef00aded2)
