### PR TITLE
Gc 80 made all commands non tty supportive

### DIFF
--- a/commands/application_commands/init
+++ b/commands/application_commands/init
@@ -40,7 +40,7 @@ echo "project name: ${PROJECT_NAME}"
 if ! ls $GRPL_WORKDIR | grep 'grapple-template' >/dev/null 2>&1; then
   # clone the grapple-template repo
   check_and_install_git
-  gum spin --title "cloning grapple template" --show-output -- git clone "https://github.com/grapple-solutions/grapple-template.git" $PROJECT_NAME
+  eval "$(getGumSpinnerOrLogger "cloning grapple template" ) git clone \"https://github.com/grapple-solutions/grapple-template.git\" $PROJECT_NAME"
 fi
 
 awk -v repl="$PROJECT_NAME" '{gsub("grapple-template", repl)}1' "$PROJECT_NAME/README.md" > temp && mv temp "$PROJECT_NAME/README.md"

--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -53,13 +53,16 @@ echo "selected target platform: ${TARGET_PLATFORM}"
 # if CIVO, then pre-set the configuration params
 if [ "${TARGET_PLATFORM}" = $CIVO ]; then
 
-    # first check if civo is installed or not, if not? then install it
-    check_and_install_civo
+  # first check if civo is installed or not, if not? then install it
+  check_and_install_civo
 
   if [ "${CIVO_CLUSTER_ID}" = "" ] || [ "${CIVO_MASTER_IP}" = "" ]; then
 
     if grep '"apikeys":{}' ~/.civo.json && [ $TTY == "enabled" ]; then
       CIVO_API_KEY=$(prompt_for_input_with_validation "Enter CIVO API KEY: " "Provide the civo api key to be used - valide api key is required" "$non_empty_regex" "Invalid api key format. Please try again." || exit $?)
+    fi
+
+    if [ "${CIVO_API_KEY}" != "" ]; then
       civo apikey add grapple $CIVO_API_KEY
       civo apikey current grapple
     fi
@@ -70,16 +73,16 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
 
     if [ $TTY == "enabled" ]; then
       CIVO_REGION=$(if [ "${CIVO_REGION}" != "" ]; then echo ${CIVO_REGION}; else gum spin --title "fetching civo regions" --show-output -- civo region ls -o custom -f code | gum choose; fi)
-      civo region use ${CIVO_REGION} | true
     fi 
+    civo region use ${CIVO_REGION} | true
 
     if [ "${CIVO_CLUSTER}" != "" ]; then 
       is_correct_civo_cluster_provided $CIVO_CLUSTER 
     fi
 
     if [ $TTY == "enabled" ]; then
-    CIVO_CLUSTER=$(if [ "${CIVO_CLUSTER}" != "" ]; then echo ${CIVO_CLUSTER}; else if gum spin --title "fetching civo clusters" -- civo k8s ls -o custom -f name; then civo k8s ls -o custom -f name | gum choose; else echo ""; fi; fi)
-    echo "selected civo cluster: ${CIVO_CLUSTER}"
+      CIVO_CLUSTER=$(if [ "${CIVO_CLUSTER}" != "" ]; then echo ${CIVO_CLUSTER}; else if gum spin --title "fetching civo clusters" -- civo k8s ls -o custom -f name; then civo k8s ls -o custom -f name | gum choose; else echo ""; fi; fi)
+      echo "selected civo cluster: ${CIVO_CLUSTER}"
     fi
 
     if ! eval "$(getGumSpinnerOrLogger "switching to ${CIVO_CLUSTER}") civo k8s config ${CIVO_CLUSTER} --save --switch"; then
@@ -103,7 +106,7 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
   CIVO_CLUSTER_NAME=${CIVO_CLUSTER}
 
   if [ $TTY == "enabled" ]; then
-    CIVO_CLUSTER_ID=$(if [ "${CIVO_CLUSTER_ID}" != "" ] then echo ${CIVO_CLUSTER_ID}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_ID: " "Provide an ID for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
+    CIVO_CLUSTER_ID=$(if [ "${CIVO_CLUSTER_ID}" != "" ]; then echo ${CIVO_CLUSTER_ID}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_ID: " "Provide an ID for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
     echo "selected civo cluster ID: ${CIVO_CLUSTER_ID}"
   fi
 
@@ -112,10 +115,9 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
     echo "selected civo cluster name: ${CIVO_CLUSTER_NAME}"
   fi
 
-  if [ $TTY == "enabled" ]; then
-    CIVO_MASTER_IP=$(if [ "${CIVO_MASTER_IP}" != "" ]; then echo ${CIVO_MASTER_IP}; else civo k8s show ${CIVO_CLUSTER} -o custom -f "MasterIP"; fi) || exit $?
-    echo "selected civo master ip: ${CIVO_MASTER_IP}"
-  fi
+  CIVO_MASTER_IP=$(if [ "${CIVO_MASTER_IP}" != "" ]; then echo ${CIVO_MASTER_IP}; else civo k8s show ${CIVO_CLUSTER} -o custom -f "MasterIP"; fi) || exit $?
+  echo "selected civo master ip: ${CIVO_MASTER_IP}"
+
   #check if input from params is valid or not
   if [ "${CIVO_EMAIL_ADDRESS}" != "" ]; then 
     is_value_correct_wrt_regex $CIVO_EMAIL_ADDRESS $email_regex "Invalid email address format. Please try again"
@@ -124,6 +126,7 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
     CIVO_EMAIL_ADDRESS=$(if [ "${CIVO_EMAIL_ADDRESS}" != "" ]; then echo ${CIVO_EMAIL_ADDRESS}; else prompt_for_input_with_validation "Enter CIVO_EMAIL_ADDRESS: " "Provide the email address to be used - valide email address is required" "$email_regex" "Invalid email address format. Please try again."; fi) || exit $?
     echo "selected civo email address: ${CIVO_EMAIL_ADDRESS}"
   fi
+  
 fi
 
 # if CIVO, then pre-set the configuration params

--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -66,20 +66,20 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
     if [ "${CIVO_REGION}" != "" ]; then 
       is_correct_civo_region_provided $CIVO_REGION 
     fi
-    CIVO_REGION=$(if [ "${CIVO_REGION}" != ""] && [ $TTY == "enabled"]; then echo ${CIVO_REGION}; else gum spin --title "fetching civo regions" --show-output -- civo region ls -o custom -f code | gum choose; fi)
+    CIVO_REGION=$(if [ "${CIVO_REGION}" != "" ] && [ $TTY == "enabled" ]; then echo ${CIVO_REGION}; else gum spin --title "fetching civo regions" --show-output -- civo region ls -o custom -f code | gum choose; fi)
     civo region use ${CIVO_REGION} | true
 
     if [ "${CIVO_CLUSTER}" != "" ]; then 
       is_correct_civo_cluster_provided $CIVO_CLUSTER 
     fi
-    CIVO_CLUSTER=$(if [ "${CIVO_CLUSTER}" != "" ] && [ $TTY == "enabled"]; then echo ${CIVO_CLUSTER}; else if gum spin --title "fetching civo clusters" -- civo k8s ls -o custom -f name; then civo k8s ls -o custom -f name | gum choose; else echo ""; fi; fi)
+    CIVO_CLUSTER=$(if [ "${CIVO_CLUSTER}" != "" ] && [ $TTY == "enabled" ]; then echo ${CIVO_CLUSTER}; else if gum spin --title "fetching civo clusters" -- civo k8s ls -o custom -f name; then civo k8s ls -o custom -f name | gum choose; else echo ""; fi; fi)
     echo "selected civo cluster: ${CIVO_CLUSTER}"
     eval "$(getGumSpinnerOrLogger "switching to ${CIVO_CLUSTER}") civo k8s config ${CIVO_CLUSTER} --save --switch"
     extract_kubectl_cli_version
 
     # if a CIVO cluster was selected, pre-set the configuration
-    CIVO_CLUSTER_ID=$(eval "$(getGumSpinnerOrLogger "fetching cluster id of ${CIVO_CLUSTER} cluster") civo k8s show ${CIVO_CLUSTER} -o custom -f ID)")
-
+    CIVO_CLUSTER_ID=$(eval "$(getGumSpinnerOrLogger "fetching cluster id of ${CIVO_CLUSTER} cluster") civo k8s show ${CIVO_CLUSTER} -o custom -f ID")
+    
     GRAPPLE_DNS=${CIVO_CLUSTER}
   else
     GRAPPLE_DNS=${CIVO_CLUSTER}
@@ -88,10 +88,10 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
   GRAPPLE_DOMAIN=".grapple-demo.com"
   CIVO_CLUSTER_NAME=${CIVO_CLUSTER}
   
-  CIVO_CLUSTER_ID=$(if [ "${CIVO_CLUSTER_ID}" != "" ] && [ $TTY == "enabled"]; then echo ${CIVO_CLUSTER_ID}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_ID: " "Provide an ID for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
+  CIVO_CLUSTER_ID=$(if [ "${CIVO_CLUSTER_ID}" != "" ] && [ $TTY == "enabled" ]; then echo ${CIVO_CLUSTER_ID}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_ID: " "Provide an ID for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
   echo "selected civo cluster ID: ${CIVO_CLUSTER_ID}"
 
-  CIVO_CLUSTER_NAME=$(if [ "${CIVO_CLUSTER_NAME}" != "" ] && [ $TTY == "enabled"]; then echo ${CIVO_CLUSTER_NAME}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_NAME: " "Provide an name for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
+  CIVO_CLUSTER_NAME=$(if [ "${CIVO_CLUSTER_NAME}" != "" ] && [ $TTY == "enabled" ]; then echo ${CIVO_CLUSTER_NAME}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_NAME: " "Provide an name for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
   echo "selected civo cluster name: ${CIVO_CLUSTER_NAME}"
 
   CIVO_MASTER_IP=$(if [ "${CIVO_MASTER_IP}" != "" ]; then echo ${CIVO_MASTER_IP}; else civo k8s show ${CIVO_CLUSTER} -o custom -f "MasterIP"; fi) || exit $?
@@ -101,7 +101,7 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
   if [ "${CIVO_EMAIL_ADDRESS}" != "" ]; then 
     is_value_correct_wrt_regex $CIVO_EMAIL_ADDRESS $email_regex "Invalid email address format. Please try again"
   fi
-  CIVO_EMAIL_ADDRESS=$(if [ "${CIVO_EMAIL_ADDRESS}" != "" ] && [ $TTY == "enabled"]; then echo ${CIVO_EMAIL_ADDRESS}; else prompt_for_input_with_validation "Enter CIVO_EMAIL_ADDRESS: " "Provide the email address to be used - valide email address is required" "$email_regex" "Invalid email address format. Please try again."; fi) || exit $?
+  CIVO_EMAIL_ADDRESS=$(if [ "${CIVO_EMAIL_ADDRESS}" != "" ] && [ $TTY == "enabled" ]; then echo ${CIVO_EMAIL_ADDRESS}; else prompt_for_input_with_validation "Enter CIVO_EMAIL_ADDRESS: " "Provide the email address to be used - valide email address is required" "$email_regex" "Invalid email address format. Please try again."; fi) || exit $?
   echo "selected civo email address: ${CIVO_EMAIL_ADDRESS}"
 
 fi
@@ -172,14 +172,14 @@ fi
 
 # Prompt for GRAPPLE_DNS, CIVO_CLUSTER_ID, etc. using gum
 if [ "${TARGET_PLATFORM}" != $Minikube ]; then
-  GRAPPLE_DNS=$(if [ "${GRAPPLE_DNS}" != "" ] && [ $TTY == "enabled"]; then echo ${GRAPPLE_DNS}; else prompt_for_input_with_validation "Enter GRAPPLE_DNS: " "Valid DNS name is required" "$grpl_dns_regex" "Invalid DNS name format. Please try again."; fi) || exit $?
+  GRAPPLE_DNS=$(if [ "${GRAPPLE_DNS}" != "" ] && [ $TTY == "enabled" ]; then echo ${GRAPPLE_DNS}; else prompt_for_input_with_validation "Enter GRAPPLE_DNS: " "Valid DNS name is required" "$grpl_dns_regex" "Invalid DNS name format. Please try again."; fi) || exit $?
   echo "installing dns: ${GRAPPLE_DNS}"
 fi
 
 if [ "${GRAPPLE_VERSION}" != "" ]; then 
   is_correct_grapple_version_provided $GRAPPLE_VERSION 
 fi 
-GRAPPLE_VERSION=$(if [ "${GRAPPLE_VERSION}" != "" ] && [ $TTY == "enabled"]; then echo ${GRAPPLE_VERSION}; else gum choose "${GRAPPLE_AVAILABLE_VERSIONS[@]}"; fi) || exit $? # not sure if both GRAPPLE_VERSION & VERSION are needed
+GRAPPLE_VERSION=$(if [ "${GRAPPLE_VERSION}" != "" ] && [ $TTY == "enabled" ]; then echo ${GRAPPLE_VERSION}; else gum choose "${GRAPPLE_AVAILABLE_VERSIONS[@]}"; fi) || exit $? # not sure if both GRAPPLE_VERSION & VERSION are needed
 echo "installing grapple version: ${GRAPPLE_VERSION}"
 
 # VERSION=$(prompt_for_input_with_validation "Enter version of the grapple solution framework: " "Semver version is expected. Default value if empty: 0.2.0" "$non_empty_regex" "Version cannot be empty." "0.2.0") || exit $?

--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -52,12 +52,12 @@ echo "selected target platform: ${TARGET_PLATFORM}"
 # if CIVO, then pre-set the configuration params
 if [ "${TARGET_PLATFORM}" = $CIVO ]; then
 
-
-  if [ "${CIVO_CLUSTER_ID}" = "" ] || [ "${CIVO_MASTER_IP}" = "" ]; then
     # first check if civo is installed or not, if not? then install it
     check_and_install_civo
 
-    if grep '"apikeys":{}' ~/.civo.json; then
+  if [ "${CIVO_CLUSTER_ID}" = "" ] || [ "${CIVO_MASTER_IP}" = "" ]; then
+
+    if grep '"apikeys":{}' ~/.civo.json && [ $TTY == "enabled" ]; then
       CIVO_API_KEY=$(prompt_for_input_with_validation "Enter CIVO API KEY: " "Provide the civo api key to be used - valide api key is required" "$non_empty_regex" "Invalid api key format. Please try again." || exit $?)
       civo apikey add grapple $CIVO_API_KEY
       civo apikey current grapple
@@ -66,44 +66,59 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
     if [ "${CIVO_REGION}" != "" ]; then 
       is_correct_civo_region_provided $CIVO_REGION 
     fi
-    CIVO_REGION=$(if [ "${CIVO_REGION}" != "" ] && [ $TTY == "enabled" ]; then echo ${CIVO_REGION}; else gum spin --title "fetching civo regions" --show-output -- civo region ls -o custom -f code | gum choose; fi)
-    civo region use ${CIVO_REGION} | true
+
+    if [ $TTY == "enabled" ]; then
+      CIVO_REGION=$(if [ "${CIVO_REGION}" != "" ]; then echo ${CIVO_REGION}; else gum spin --title "fetching civo regions" --show-output -- civo region ls -o custom -f code | gum choose; fi)
+      civo region use ${CIVO_REGION} | true
+    fi 
 
     if [ "${CIVO_CLUSTER}" != "" ]; then 
       is_correct_civo_cluster_provided $CIVO_CLUSTER 
     fi
-    CIVO_CLUSTER=$(if [ "${CIVO_CLUSTER}" != "" ] && [ $TTY == "enabled" ]; then echo ${CIVO_CLUSTER}; else if gum spin --title "fetching civo clusters" -- civo k8s ls -o custom -f name; then civo k8s ls -o custom -f name | gum choose; else echo ""; fi; fi)
-    echo "selected civo cluster: ${CIVO_CLUSTER}"
-    eval "$(getGumSpinnerOrLogger "switching to ${CIVO_CLUSTER}") civo k8s config ${CIVO_CLUSTER} --save --switch"
-    extract_kubectl_cli_version
 
-    # if a CIVO cluster was selected, pre-set the configuration
-    CIVO_CLUSTER_ID=$(eval "$(getGumSpinnerOrLogger "fetching cluster id of ${CIVO_CLUSTER} cluster") civo k8s show ${CIVO_CLUSTER} -o custom -f ID")
-    
-    GRAPPLE_DNS=${CIVO_CLUSTER}
+    if [ $TTY == "enabled" ]; then
+      CIVO_CLUSTER=$(if [ "${CIVO_CLUSTER}" != "" ]; then echo ${CIVO_CLUSTER}; else if gum spin --title "fetching civo clusters" -- civo k8s ls -o custom -f name; then civo k8s ls -o custom -f name | gum choose; else echo ""; fi; fi)
+      echo "selected civo cluster: ${CIVO_CLUSTER}"
+    fi
+
+    if [ "${CIVO_CLUSTER}" != "" ]; then
+      eval "$(getGumSpinnerOrLogger "switching to ${CIVO_CLUSTER}") civo k8s config ${CIVO_CLUSTER} --save --switch"
+      extract_kubectl_cli_version
+      # if a CIVO cluster was selected, pre-set the configuration
+      CIVO_CLUSTER_ID=$(eval "$(getGumSpinnerOrLogger "fetching cluster id of ${CIVO_CLUSTER} cluster") civo k8s show ${CIVO_CLUSTER} -o custom -f ID")
+      GRAPPLE_DNS=${CIVO_CLUSTER}
+    fi
+
+
   else
     GRAPPLE_DNS=${CIVO_CLUSTER}
   fi
 
   GRAPPLE_DOMAIN=".grapple-demo.com"
   CIVO_CLUSTER_NAME=${CIVO_CLUSTER}
-  
-  CIVO_CLUSTER_ID=$(if [ "${CIVO_CLUSTER_ID}" != "" ] && [ $TTY == "enabled" ]; then echo ${CIVO_CLUSTER_ID}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_ID: " "Provide an ID for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
-  echo "selected civo cluster ID: ${CIVO_CLUSTER_ID}"
 
-  CIVO_CLUSTER_NAME=$(if [ "${CIVO_CLUSTER_NAME}" != "" ] && [ $TTY == "enabled" ]; then echo ${CIVO_CLUSTER_NAME}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_NAME: " "Provide an name for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
-  echo "selected civo cluster name: ${CIVO_CLUSTER_NAME}"
+  if [ $TTY == "enabled" ]; then
+    CIVO_CLUSTER_ID=$(if [ "${CIVO_CLUSTER_ID}" != "" ] then echo ${CIVO_CLUSTER_ID}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_ID: " "Provide an ID for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
+    echo "selected civo cluster ID: ${CIVO_CLUSTER_ID}"
+  fi
 
-  CIVO_MASTER_IP=$(if [ "${CIVO_MASTER_IP}" != "" ]; then echo ${CIVO_MASTER_IP}; else civo k8s show ${CIVO_CLUSTER} -o custom -f "MasterIP"; fi) || exit $?
-  echo "selected civo master ip: ${CIVO_MASTER_IP}"
+  if [ $TTY == "enabled" ]; then
+    CIVO_CLUSTER_NAME=$(if [ "${CIVO_CLUSTER_NAME}" != "" ]; then echo ${CIVO_CLUSTER_NAME}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_NAME: " "Provide an name for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
+    echo "selected civo cluster name: ${CIVO_CLUSTER_NAME}"
+  fi
 
+  if [ $TTY == "enabled" ]; then
+    CIVO_MASTER_IP=$(if [ "${CIVO_MASTER_IP}" != "" ]; then echo ${CIVO_MASTER_IP}; else civo k8s show ${CIVO_CLUSTER} -o custom -f "MasterIP"; fi) || exit $?
+    echo "selected civo master ip: ${CIVO_MASTER_IP}"
+  fi
   #check if input from params is valid or not
   if [ "${CIVO_EMAIL_ADDRESS}" != "" ]; then 
     is_value_correct_wrt_regex $CIVO_EMAIL_ADDRESS $email_regex "Invalid email address format. Please try again"
   fi
-  CIVO_EMAIL_ADDRESS=$(if [ "${CIVO_EMAIL_ADDRESS}" != "" ] && [ $TTY == "enabled" ]; then echo ${CIVO_EMAIL_ADDRESS}; else prompt_for_input_with_validation "Enter CIVO_EMAIL_ADDRESS: " "Provide the email address to be used - valide email address is required" "$email_regex" "Invalid email address format. Please try again."; fi) || exit $?
-  echo "selected civo email address: ${CIVO_EMAIL_ADDRESS}"
-
+  if [ $TTY == "enabled" ]; then
+    CIVO_EMAIL_ADDRESS=$(if [ "${CIVO_EMAIL_ADDRESS}" != "" ]; then echo ${CIVO_EMAIL_ADDRESS}; else prompt_for_input_with_validation "Enter CIVO_EMAIL_ADDRESS: " "Provide the email address to be used - valide email address is required" "$email_regex" "Invalid email address format. Please try again."; fi) || exit $?
+    echo "selected civo email address: ${CIVO_EMAIL_ADDRESS}"
+  fi
 fi
 
 # if CIVO, then pre-set the configuration params
@@ -172,16 +187,19 @@ fi
 
 # Prompt for GRAPPLE_DNS, CIVO_CLUSTER_ID, etc. using gum
 if [ "${TARGET_PLATFORM}" != $Minikube ]; then
-  GRAPPLE_DNS=$(if [ "${GRAPPLE_DNS}" != "" ] && [ $TTY == "enabled" ]; then echo ${GRAPPLE_DNS}; else prompt_for_input_with_validation "Enter GRAPPLE_DNS: " "Valid DNS name is required" "$grpl_dns_regex" "Invalid DNS name format. Please try again."; fi) || exit $?
-  echo "installing dns: ${GRAPPLE_DNS}"
+  if [ $TTY == "enabled" ]; then
+    GRAPPLE_DNS=$(if [ "${GRAPPLE_DNS}" != "" ]; then echo ${GRAPPLE_DNS}; else prompt_for_input_with_validation "Enter GRAPPLE_DNS: " "Valid DNS name is required" "$grpl_dns_regex" "Invalid DNS name format. Please try again."; fi) || exit $?
+    echo "installing dns: ${GRAPPLE_DNS}"
+  fi
 fi
 
 if [ "${GRAPPLE_VERSION}" != "" ]; then 
   is_correct_grapple_version_provided $GRAPPLE_VERSION 
 fi 
-GRAPPLE_VERSION=$(if [ "${GRAPPLE_VERSION}" != "" ] && [ $TTY == "enabled" ]; then echo ${GRAPPLE_VERSION}; else gum choose "${GRAPPLE_AVAILABLE_VERSIONS[@]}"; fi) || exit $? # not sure if both GRAPPLE_VERSION & VERSION are needed
-echo "installing grapple version: ${GRAPPLE_VERSION}"
-
+if [ $TTY == "enabled" ]; then
+  GRAPPLE_VERSION=$(if [ "${GRAPPLE_VERSION}" != "" ]; then echo ${GRAPPLE_VERSION}; else gum choose "${GRAPPLE_AVAILABLE_VERSIONS[@]}"; fi) || exit $? # not sure if both GRAPPLE_VERSION & VERSION are needed
+  echo "installing grapple version: ${GRAPPLE_VERSION}"
+fi
 # VERSION=$(prompt_for_input_with_validation "Enter version of the grapple solution framework: " "Semver version is expected. Default value if empty: 0.2.0" "$non_empty_regex" "Version cannot be empty." "0.2.0") || exit $?
 
 # The script then proceeds to dynamically generate values-override.yaml with user inputs

--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -71,19 +71,14 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
       is_correct_civo_region_provided $CIVO_REGION 
     fi
 
-    if [ $TTY == "enabled" ]; then
-      CIVO_REGION=$(if [ "${CIVO_REGION}" != "" ]; then echo ${CIVO_REGION}; else gum spin --title "fetching civo regions" --show-output -- civo region ls -o custom -f code | gum choose; fi)
-    fi 
+    CIVO_REGION=$(if [ "${CIVO_REGION}" != "" ]; then echo ${CIVO_REGION}; else [ $TTY == "enabled" ] &&  gum spin --title "fetching civo regions" --show-output -- civo region ls -o custom -f code | gum choose; fi)
     civo region use ${CIVO_REGION} | true
 
     if [ "${CIVO_CLUSTER}" != "" ]; then 
       is_correct_civo_cluster_provided $CIVO_CLUSTER 
     fi
-
-    if [ $TTY == "enabled" ]; then
-      CIVO_CLUSTER=$(if [ "${CIVO_CLUSTER}" != "" ]; then echo ${CIVO_CLUSTER}; else if gum spin --title "fetching civo clusters" -- civo k8s ls -o custom -f name; then civo k8s ls -o custom -f name | gum choose; else echo ""; fi; fi)
-      echo "selected civo cluster: ${CIVO_CLUSTER}"
-    fi
+    CIVO_CLUSTER=$(if [ "${CIVO_CLUSTER}" != "" ]; then echo ${CIVO_CLUSTER}; else if [ $TTY == "enabled" ] && gum spin --title "fetching civo clusters" -- civo k8s ls -o custom -f name; then civo k8s ls -o custom -f name | gum choose; else echo ""; fi; fi)
+    echo "selected civo cluster: ${CIVO_CLUSTER}"
 
     if ! eval "$(getGumSpinnerOrLogger "switching to ${CIVO_CLUSTER}") civo k8s config ${CIVO_CLUSTER} --save --switch"; then
       if ! eval "$(getGumSpinnerOrLogger "checking if cluster is accessible") kubectl get ns"; then
@@ -105,15 +100,11 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
   GRAPPLE_DOMAIN=".grapple-demo.com"
   CIVO_CLUSTER_NAME=${CIVO_CLUSTER}
 
-  if [ $TTY == "enabled" ]; then
-    CIVO_CLUSTER_ID=$(if [ "${CIVO_CLUSTER_ID}" != "" ]; then echo ${CIVO_CLUSTER_ID}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_ID: " "Provide an ID for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
-    echo "selected civo cluster ID: ${CIVO_CLUSTER_ID}"
-  fi
+  CIVO_CLUSTER_ID=$(if [ "${CIVO_CLUSTER_ID}" != "" ]; then echo ${CIVO_CLUSTER_ID}; else [ $TTY == "enabled" ] && prompt_for_input_with_validation "Enter CIVO_CLUSTER_ID: " "Provide an ID for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
+  echo "selected civo cluster ID: ${CIVO_CLUSTER_ID}"
 
-  if [ $TTY == "enabled" ]; then
-    CIVO_CLUSTER_NAME=$(if [ "${CIVO_CLUSTER_NAME}" != "" ]; then echo ${CIVO_CLUSTER_NAME}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_NAME: " "Provide an name for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
-    echo "selected civo cluster name: ${CIVO_CLUSTER_NAME}"
-  fi
+  CIVO_CLUSTER_NAME=$(if [ "${CIVO_CLUSTER_NAME}" != "" ]; then echo ${CIVO_CLUSTER_NAME}; else [ $TTY == "enabled" ] && prompt_for_input_with_validation "Enter CIVO_CLUSTER_NAME: " "Provide an name for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
+  echo "selected civo cluster name: ${CIVO_CLUSTER_NAME}"
 
   CIVO_MASTER_IP=$(if [ "${CIVO_MASTER_IP}" != "" ]; then echo ${CIVO_MASTER_IP}; else civo k8s show ${CIVO_CLUSTER} -o custom -f "MasterIP"; fi) || exit $?
   echo "selected civo master ip: ${CIVO_MASTER_IP}"
@@ -122,11 +113,10 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
   if [ "${CIVO_EMAIL_ADDRESS}" != "" ]; then 
     is_value_correct_wrt_regex $CIVO_EMAIL_ADDRESS $email_regex "Invalid email address format. Please try again"
   fi
-  if [ $TTY == "enabled" ]; then
-    CIVO_EMAIL_ADDRESS=$(if [ "${CIVO_EMAIL_ADDRESS}" != "" ]; then echo ${CIVO_EMAIL_ADDRESS}; else prompt_for_input_with_validation "Enter CIVO_EMAIL_ADDRESS: " "Provide the email address to be used - valide email address is required" "$email_regex" "Invalid email address format. Please try again."; fi) || exit $?
-    echo "selected civo email address: ${CIVO_EMAIL_ADDRESS}"
-  fi
-  
+  CIVO_EMAIL_ADDRESS=$(if [ "${CIVO_EMAIL_ADDRESS}" != "" ]; then echo ${CIVO_EMAIL_ADDRESS}; else [ $TTY == "enabled" ] && prompt_for_input_with_validation "Enter CIVO_EMAIL_ADDRESS: " "Provide the email address to be used - valide email address is required" "$email_regex" "Invalid email address format. Please try again."; fi) || exit $?
+  echo "selected civo email address: ${CIVO_EMAIL_ADDRESS}"
+
+
 fi
 
 # if CIVO, then pre-set the configuration params
@@ -195,19 +185,16 @@ fi
 
 # Prompt for GRAPPLE_DNS, CIVO_CLUSTER_ID, etc. using gum
 if [ "${TARGET_PLATFORM}" != $Minikube ]; then
-  if [ $TTY == "enabled" ]; then
-    GRAPPLE_DNS=$(if [ "${GRAPPLE_DNS}" != "" ]; then echo ${GRAPPLE_DNS}; else prompt_for_input_with_validation "Enter GRAPPLE_DNS: " "Valid DNS name is required" "$grpl_dns_regex" "Invalid DNS name format. Please try again."; fi) || exit $?
-    echo "installing dns: ${GRAPPLE_DNS}"
-  fi
+  GRAPPLE_DNS=$(if [ "${GRAPPLE_DNS}" != "" ]; then echo ${GRAPPLE_DNS}; else [ $TTY == "enabled" ] && prompt_for_input_with_validation "Enter GRAPPLE_DNS: " "Valid DNS name is required" "$grpl_dns_regex" "Invalid DNS name format. Please try again."; fi) || exit $?
+  echo "installing dns: ${GRAPPLE_DNS}"
 fi
 
 if [ "${GRAPPLE_VERSION}" != "" ]; then 
   is_correct_grapple_version_provided $GRAPPLE_VERSION 
 fi 
-if [ $TTY == "enabled" ]; then
-  GRAPPLE_VERSION=$(if [ "${GRAPPLE_VERSION}" != "" ]; then echo ${GRAPPLE_VERSION}; else gum choose "${GRAPPLE_AVAILABLE_VERSIONS[@]}"; fi) || exit $? # not sure if both GRAPPLE_VERSION & VERSION are needed
-  echo "installing grapple version: ${GRAPPLE_VERSION}"
-fi
+GRAPPLE_VERSION=$(if [ "${GRAPPLE_VERSION}" != "" ]; then echo ${GRAPPLE_VERSION}; else [ $TTY == "enabled" ] && gum choose "${GRAPPLE_AVAILABLE_VERSIONS[@]}"; fi) || exit $? # not sure if both GRAPPLE_VERSION & VERSION are needed
+echo "installing grapple version: ${GRAPPLE_VERSION}"
+
 # VERSION=$(prompt_for_input_with_validation "Enter version of the grapple solution framework: " "Semver version is expected. Default value if empty: 0.2.0" "$non_empty_regex" "Version cannot be empty." "0.2.0") || exit $?
 
 # The script then proceeds to dynamically generate values-override.yaml with user inputs
@@ -278,7 +265,7 @@ helm_deploy() {
 
   echo "Deploying $i with version $version"
 
-  if ! eval "$(getGumSpinnerOrLogger "Installing ${i} component") helm upgrade --install $i oci://public.ecr.aws/${awsregistry}/$i -n ${NS} ${version} --create-namespace -f /tmp/values-override.yaml $values_yaml_file_names" >/dev/null; then
+  if ! eval "$(getGumSpinnerOrLogger "Installing ${i} component") helm upgrade --install $i oci://public.ecr.aws/${awsregistry}/$i -n ${NS} ${version} --create-namespace -f /tmp/values-override.yaml $values_yaml_file_names" >/dev/null 2>&1; then
     
     if [ "$loggedOut" = "true" ]; then
       exit 1

--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -56,46 +56,41 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
   # first check if civo is installed or not, if not? then install it
   check_and_install_civo
 
-  if [ "${CIVO_CLUSTER_ID}" = "" ] || [ "${CIVO_MASTER_IP}" = "" ]; then
-
-    if grep '"apikeys":{}' ~/.civo.json && [ $TTY == "enabled" ]; then
-      CIVO_API_KEY=$(prompt_for_input_with_validation "Enter CIVO API KEY: " "Provide the civo api key to be used - valide api key is required" "$non_empty_regex" "Invalid api key format. Please try again." || exit $?)
-    fi
-
-    if [ "${CIVO_API_KEY}" != "" ]; then
-      civo apikey add grapple $CIVO_API_KEY
-      civo apikey current grapple
-    fi
-
-    if [ "${CIVO_REGION}" != "" ]; then 
-      is_correct_civo_region_provided $CIVO_REGION 
-    fi
-
-    CIVO_REGION=$(if [ "${CIVO_REGION}" != "" ]; then echo ${CIVO_REGION}; else [ $TTY == "enabled" ] &&  gum spin --title "fetching civo regions" --show-output -- civo region ls -o custom -f code | gum choose; fi)
-    civo region use ${CIVO_REGION} | true
-
-    if [ "${CIVO_CLUSTER}" != "" ]; then 
-      is_correct_civo_cluster_provided $CIVO_CLUSTER 
-    fi
-    CIVO_CLUSTER=$(if [ "${CIVO_CLUSTER}" != "" ]; then echo ${CIVO_CLUSTER}; else if [ $TTY == "enabled" ] && gum spin --title "fetching civo clusters" -- civo k8s ls -o custom -f name; then civo k8s ls -o custom -f name | gum choose; else echo ""; fi; fi)
-    echo "selected civo cluster: ${CIVO_CLUSTER}"
-
-    if ! eval "$(getGumSpinnerOrLogger "switching to ${CIVO_CLUSTER}") civo k8s config ${CIVO_CLUSTER} --save --switch"; then
-      if ! eval "$(getGumSpinnerOrLogger "checking if cluster is accessible") kubectl get ns"; then
-        status_log $TYPE_ERROR "Failed to switch to ${CIVO_CLUSTER}"
-        exit 1
-      fi
-    fi
-
-    extract_kubectl_cli_version
-
-    # if a CIVO cluster was selected, pre-set the configuration
-    CIVO_CLUSTER_ID=$(eval "$(getGumSpinnerOrLogger "fetching cluster id of ${CIVO_CLUSTER} cluster") civo k8s show ${CIVO_CLUSTER} -o custom -f ID")
-
-    GRAPPLE_DNS=${CIVO_CLUSTER}
-  else
-    GRAPPLE_DNS=${CIVO_CLUSTER}
+  if [ "${CIVO_API_KEY}" == "" ] && grep '"apikeys":{}' ~/.civo.json && [ $TTY == "enabled" ]; then
+    CIVO_API_KEY=$(prompt_for_input_with_validation "Enter CIVO API KEY: " "Provide the civo api key to be used - valide api key is required" "$non_empty_regex" "Invalid api key format. Please try again." || exit $?)
   fi
+
+  if [ "${CIVO_API_KEY}" != "" ]; then
+    civo apikey add grapple $CIVO_API_KEY
+    civo apikey current grapple
+  fi
+
+  if [ "${CIVO_REGION}" != "" ]; then 
+    is_correct_civo_region_provided $CIVO_REGION 
+  fi
+
+  CIVO_REGION=$(if [ "${CIVO_REGION}" != "" ]; then echo ${CIVO_REGION}; else [ $TTY == "enabled" ] &&  gum spin --title "fetching civo regions" --show-output -- civo region ls -o custom -f code | gum choose; fi)
+  civo region use ${CIVO_REGION} | true
+
+  if [ "${CIVO_CLUSTER}" != "" ]; then 
+    is_correct_civo_cluster_provided $CIVO_CLUSTER 
+  fi
+  CIVO_CLUSTER=$(if [ "${CIVO_CLUSTER}" != "" ]; then echo ${CIVO_CLUSTER}; else if [ $TTY == "enabled" ] && gum spin --title "fetching civo clusters" -- civo k8s ls -o custom -f name; then civo k8s ls -o custom -f name | gum choose; else echo ""; fi; fi)
+  echo "selected civo cluster: ${CIVO_CLUSTER}"
+
+  if ! eval "$(getGumSpinnerOrLogger "switching to ${CIVO_CLUSTER}") civo k8s config ${CIVO_CLUSTER} --save --switch"; then
+    if ! eval "$(getGumSpinnerOrLogger "checking if cluster is accessible") kubectl get ns"; then
+      status_log $TYPE_ERROR "Failed to switch to ${CIVO_CLUSTER}"
+      exit 1
+    fi
+  fi
+
+  extract_kubectl_cli_version
+
+  # if a CIVO cluster was selected, pre-set the configuration
+  CIVO_CLUSTER_ID=$(eval "$(getGumSpinnerOrLogger "fetching cluster id of ${CIVO_CLUSTER} cluster") civo k8s show ${CIVO_CLUSTER} -o custom -f ID")
+
+  GRAPPLE_DNS=${CIVO_CLUSTER}
 
   GRAPPLE_DOMAIN=".grapple-demo.com"
   CIVO_CLUSTER_NAME=${CIVO_CLUSTER}

--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -66,19 +66,19 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
     if [ "${CIVO_REGION}" != "" ]; then 
       is_correct_civo_region_provided $CIVO_REGION 
     fi
-    CIVO_REGION=$(if [ "${CIVO_REGION}" != "" ]; then echo ${CIVO_REGION}; else gum spin --title "fetching civo regions" --show-output -- civo region ls -o custom -f code | gum choose; fi)
+    CIVO_REGION=$(if [ "${CIVO_REGION}" != ""] && [ $TTY == "enabled"]; then echo ${CIVO_REGION}; else gum spin --title "fetching civo regions" --show-output -- civo region ls -o custom -f code | gum choose; fi)
     civo region use ${CIVO_REGION} | true
 
     if [ "${CIVO_CLUSTER}" != "" ]; then 
       is_correct_civo_cluster_provided $CIVO_CLUSTER 
     fi
-    CIVO_CLUSTER=$(if [ "${CIVO_CLUSTER}" != "" ]; then echo ${CIVO_CLUSTER}; else if gum spin --title "fetching civo clusters" -- civo k8s ls -o custom -f name; then civo k8s ls -o custom -f name | gum choose; else echo ""; fi; fi)
+    CIVO_CLUSTER=$(if [ "${CIVO_CLUSTER}" != "" ] && [ $TTY == "enabled"]; then echo ${CIVO_CLUSTER}; else if gum spin --title "fetching civo clusters" -- civo k8s ls -o custom -f name; then civo k8s ls -o custom -f name | gum choose; else echo ""; fi; fi)
     echo "selected civo cluster: ${CIVO_CLUSTER}"
-    gum spin --title "switching to ${CIVO_CLUSTER}" --show-output -- civo k8s config ${CIVO_CLUSTER} --save --switch
+    eval "$(getGumSpinnerOrLogger "switching to ${CIVO_CLUSTER}") civo k8s config ${CIVO_CLUSTER} --save --switch"
     extract_kubectl_cli_version
 
     # if a CIVO cluster was selected, pre-set the configuration
-    CIVO_CLUSTER_ID=$(gum spin --title "fetching cluster id of ${CIVO_CLUSTER} cluster" --show-output -- civo k8s show ${CIVO_CLUSTER} -o custom -f ID)
+    CIVO_CLUSTER_ID=$(eval "$(getGumSpinnerOrLogger "fetching cluster id of ${CIVO_CLUSTER} cluster") civo k8s show ${CIVO_CLUSTER} -o custom -f ID)")
 
     GRAPPLE_DNS=${CIVO_CLUSTER}
   else
@@ -88,10 +88,10 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
   GRAPPLE_DOMAIN=".grapple-demo.com"
   CIVO_CLUSTER_NAME=${CIVO_CLUSTER}
   
-  CIVO_CLUSTER_ID=$(if [ "${CIVO_CLUSTER_ID}" != "" ]; then echo ${CIVO_CLUSTER_ID}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_ID: " "Provide an ID for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
+  CIVO_CLUSTER_ID=$(if [ "${CIVO_CLUSTER_ID}" != "" ] && [ $TTY == "enabled"]; then echo ${CIVO_CLUSTER_ID}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_ID: " "Provide an ID for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
   echo "selected civo cluster ID: ${CIVO_CLUSTER_ID}"
 
-  CIVO_CLUSTER_NAME=$(if [ "${CIVO_CLUSTER_NAME}" != "" ]; then echo ${CIVO_CLUSTER_NAME}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_NAME: " "Provide an name for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
+  CIVO_CLUSTER_NAME=$(if [ "${CIVO_CLUSTER_NAME}" != "" ] && [ $TTY == "enabled"]; then echo ${CIVO_CLUSTER_NAME}; else prompt_for_input_with_validation "Enter CIVO_CLUSTER_NAME: " "Provide an name for the cluster" "$non_empty_regex" "Input cannot be empty."; fi) || exit $?
   echo "selected civo cluster name: ${CIVO_CLUSTER_NAME}"
 
   CIVO_MASTER_IP=$(if [ "${CIVO_MASTER_IP}" != "" ]; then echo ${CIVO_MASTER_IP}; else civo k8s show ${CIVO_CLUSTER} -o custom -f "MasterIP"; fi) || exit $?
@@ -101,7 +101,7 @@ if [ "${TARGET_PLATFORM}" = $CIVO ]; then
   if [ "${CIVO_EMAIL_ADDRESS}" != "" ]; then 
     is_value_correct_wrt_regex $CIVO_EMAIL_ADDRESS $email_regex "Invalid email address format. Please try again"
   fi
-  CIVO_EMAIL_ADDRESS=$(if [ "${CIVO_EMAIL_ADDRESS}" != "" ]; then echo ${CIVO_EMAIL_ADDRESS}; else prompt_for_input_with_validation "Enter CIVO_EMAIL_ADDRESS: " "Provide the email address to be used - valide email address is required" "$email_regex" "Invalid email address format. Please try again."; fi) || exit $?
+  CIVO_EMAIL_ADDRESS=$(if [ "${CIVO_EMAIL_ADDRESS}" != "" ] && [ $TTY == "enabled"]; then echo ${CIVO_EMAIL_ADDRESS}; else prompt_for_input_with_validation "Enter CIVO_EMAIL_ADDRESS: " "Provide the email address to be used - valide email address is required" "$email_regex" "Invalid email address format. Please try again."; fi) || exit $?
   echo "selected civo email address: ${CIVO_EMAIL_ADDRESS}"
 
 fi
@@ -120,7 +120,7 @@ if [ "${TARGET_PLATFORM}" = $Minikube ]; then
   # check if minikube cluster is running or not, if not? then start it
   if ! minikube status | grep "host: Running"; then
       echo "Minikube is not running. Starting Minikube..."
-      if ! gum spin --title "minikube is not running, now starting minikube" --show-output -- minikube start; then
+      if ! eval "$(getGumSpinnerOrLogger "minikube is not running, now starting minikube") minikube start"; then
         status_log $TYPE_ERROR "Error: minikube failed to start becasue docker or any driver service is not running. Details are listed below"
         minikube start >&2
       fi
@@ -172,14 +172,14 @@ fi
 
 # Prompt for GRAPPLE_DNS, CIVO_CLUSTER_ID, etc. using gum
 if [ "${TARGET_PLATFORM}" != $Minikube ]; then
-  GRAPPLE_DNS=$(if [ "${GRAPPLE_DNS}" != "" ]; then echo ${GRAPPLE_DNS}; else prompt_for_input_with_validation "Enter GRAPPLE_DNS: " "Valid DNS name is required" "$grpl_dns_regex" "Invalid DNS name format. Please try again."; fi) || exit $?
+  GRAPPLE_DNS=$(if [ "${GRAPPLE_DNS}" != "" ] && [ $TTY == "enabled"]; then echo ${GRAPPLE_DNS}; else prompt_for_input_with_validation "Enter GRAPPLE_DNS: " "Valid DNS name is required" "$grpl_dns_regex" "Invalid DNS name format. Please try again."; fi) || exit $?
   echo "installing dns: ${GRAPPLE_DNS}"
 fi
 
 if [ "${GRAPPLE_VERSION}" != "" ]; then 
   is_correct_grapple_version_provided $GRAPPLE_VERSION 
 fi 
-GRAPPLE_VERSION=$(if [ "${GRAPPLE_VERSION}" != "" ]; then echo ${GRAPPLE_VERSION}; else gum choose "${GRAPPLE_AVAILABLE_VERSIONS[@]}"; fi) || exit $? # not sure if both GRAPPLE_VERSION & VERSION are needed
+GRAPPLE_VERSION=$(if [ "${GRAPPLE_VERSION}" != "" ] && [ $TTY == "enabled"]; then echo ${GRAPPLE_VERSION}; else gum choose "${GRAPPLE_AVAILABLE_VERSIONS[@]}"; fi) || exit $? # not sure if both GRAPPLE_VERSION & VERSION are needed
 echo "installing grapple version: ${GRAPPLE_VERSION}"
 
 # VERSION=$(prompt_for_input_with_validation "Enter version of the grapple solution framework: " "Semver version is expected. Default value if empty: 0.2.0" "$non_empty_regex" "Version cannot be empty." "0.2.0") || exit $?

--- a/commands/example_commands/deploy
+++ b/commands/example_commands/deploy
@@ -56,7 +56,7 @@ if [ "${EDITION}" = "grpl-basic-dbfile" ] || [ "${EDITION}" = "grpl-basic-all" ]
   CRD=composition/muim.grsf.grpl.io && echo "wait for $CRD to be deployed:" && until kubectl get $CRD >/dev/null 2>&1; do echo -n .; sleep 1; done && echo "$CRD deployed"
   status_log $TYPE_SUCCESS "composition/muim.grsf.grpl.io is deployed"
 
-  gum spin --title "Deploying ${EDITION}" -- helm upgrade --install ${TESTNS} oci://public.ecr.aws/${awsregistry}/gras-deploy -n ${TESTNS} -f $GRPL_WORKDIR/files/test.yaml ${MINIKUBE_PATCH} --create-namespace 
+  eval "$(getGumSpinnerOrLogger "Deploying ${EDITION}") helm upgrade --install ${TESTNS} oci://public.ecr.aws/${awsregistry}/gras-deploy -n ${TESTNS} -f $GRPL_WORKDIR/files/test.yaml ${MINIKUBE_PATCH} --create-namespace "
   
   # not required anymore since downloading the file from the git repo
   # while ! kubectl get po -n ${TESTNS} -l app.kubernetes.io/name=grapi 2>/dev/null | grep grapi; do echo -n .; sleep 1; done
@@ -120,7 +120,7 @@ if [ "${EDITION}" = "grpl-basic-db" ] || [ "${EDITION}" = "grpl-basic-all" ]; th
   fi
 
 
-  gum spin --title "Deploying ${EDITION}" -- helm upgrade --install ${TESTNSDB} oci://public.ecr.aws/${awsregistry}/gras-deploy -n ${TESTNSDB} -f $GRPL_WORKDIR/files/testdb.yaml ${MINIKUBE_PATCH} --create-namespace 
+  eval "$(getGumSpinnerOrLogger "Deploying ${EDITION}") helm upgrade --install ${TESTNSDB} oci://public.ecr.aws/${awsregistry}/gras-deploy -n ${TESTNSDB} -f $GRPL_WORKDIR/files/testdb.yaml ${MINIKUBE_PATCH} --create-namespace "
 
   # not required anymore since downloading the file from the git repo
   # while ! kubectl get po -n ${TESTNSDB} -l app.kubernetes.io/name=grapi 2>/dev/null | grep grapi; do echo -n .; sleep 1; done

--- a/commands/resource_commands/deploy
+++ b/commands/resource_commands/deploy
@@ -390,7 +390,7 @@ deploy_template() {
         MINIKUBE_PATCH=""
     fi
 
-    if ! gum spin --title "Deploying template" -- helm upgrade --install ${GRAS_NAME} oci://public.ecr.aws/${awsregistry}/gras-deploy  -n ${KUBE_NS} -f $template_file_dest ${MINIKUBE_PATCH}; then
+    if ! eval "$(getGumSpinnerOrLogger "Deploying template") helm upgrade --install ${GRAS_NAME} oci://public.ecr.aws/${awsregistry}/gras-deploy  -n ${KUBE_NS} -f $template_file_dest ${MINIKUBE_PATCH}"; then
         status_log $TYPE_ERROR "Failed to deploy template, configs might be invalid"
         exit 1
     fi

--- a/commands/upgrade
+++ b/commands/upgrade
@@ -23,7 +23,7 @@ if [ "$installed_version" == "$stable_version" ]; then
   exit 0
 fi
 
-if ! gum spin --title "Upgrading grapple-cli" --show-output -- brew upgrade grapple-cli; then 
+if ! eval "$(getGumSpinnerOrLogger "Upgrading grapple-cli" ) brew upgrade grapple-cli"; then 
   errMsg="Failed to upgrade grappgle-cli"
   status_log $TYPE_INFO $errMsg
   echo $errMsg

--- a/grpl
+++ b/grpl
@@ -25,7 +25,7 @@ case "$command" in
     "$GRPL_WORKDIR/commands/install" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/install.log" >/dev/null
     ;;
   cluster|c)
-    "$GRPL_WORKDIR/commands/cluster" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/cluster.log" >/dev/null
+    "$GRPL_WORKDIR/commands/cluster" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/cluster.log" #>/dev/null
     ;;
   example|e)
     "$GRPL_WORKDIR/commands/example" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/example.log" >/dev/null

--- a/grpl
+++ b/grpl
@@ -25,7 +25,7 @@ case "$command" in
     "$GRPL_WORKDIR/commands/install" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/install.log" >/dev/null
     ;;
   cluster|c)
-    "$GRPL_WORKDIR/commands/cluster" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/cluster.log" #>/dev/null
+    "$GRPL_WORKDIR/commands/cluster" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/cluster.log" >/dev/null
     ;;
   example|e)
     "$GRPL_WORKDIR/commands/example" $(echo $@) | tee -ia "$GRPL_WORKDIR/logs/example.log" >/dev/null

--- a/utils/checks
+++ b/utils/checks
@@ -39,7 +39,7 @@ is_correct_civo_region_provided() {
 
 is_correct_civo_cluster_provided() {
 
-    output=$( eval"$(getGumSpinnerOrLogger "fetching civo regions") civo k8s ls -o custom -f name")
+    output=$( eval "$(getGumSpinnerOrLogger "fetching civo clusters") civo k8s ls -o custom -f name")
     cluster=$1
 
     # Declare an empty array

--- a/utils/checks
+++ b/utils/checks
@@ -16,7 +16,7 @@ is_correct_target_platform_provided() {
 
 is_correct_civo_region_provided() {
 
-    output=$(gum spin --title "fetching civo regions" --show-output -- civo region ls -o custom -f code) 
+    output=$( eval "$(getGumSpinnerOrLogger "fetching civo regions") civo region ls -o custom -f code") 
     region=$1
 
 
@@ -39,7 +39,7 @@ is_correct_civo_region_provided() {
 
 is_correct_civo_cluster_provided() {
 
-    output=$(gum spin --title "fetching civo clusters"  --show-output -- civo k8s ls -o custom -f name)
+    output=$( eval"$(getGumSpinnerOrLogger "fetching civo regions") civo k8s ls -o custom -f name")
     cluster=$1
 
     # Declare an empty array

--- a/utils/common
+++ b/utils/common
@@ -309,10 +309,11 @@ getGumSpinnerOrLogger() {
 
 setTTYModeState() {
   if [ -t 0 ]; then
-    TTY="enable"
+    TTY="enabled"
   else
-    TTY="disable"
+    TTY="disabled"
   fi
+
 }
 
 setTTYModeState

--- a/utils/common
+++ b/utils/common
@@ -313,9 +313,6 @@ setTTYModeState() {
   else
     TTY="disabled"
   fi
-
-
-  echo "TTY=$TTY"
 }
 
 setTTYModeState

--- a/utils/common
+++ b/utils/common
@@ -314,6 +314,8 @@ setTTYModeState() {
     TTY="disabled"
   fi
 
+
+  echo "TTY=$TTY"
 }
 
 setTTYModeState

--- a/utils/common
+++ b/utils/common
@@ -306,3 +306,13 @@ getGumSpinnerOrLogger() {
   fi
 
 }
+
+setTTYModeState() {
+  if [ -t 0 ]; then
+    TTY="enable"
+  else
+    TTY="disable"
+  fi
+}
+
+setTTYModeState

--- a/utils/constants
+++ b/utils/constants
@@ -56,4 +56,3 @@ HAS_MANY="hasMany"
 HAS_MANY_THROUGH="hasManyThrough"
 HAS_ONE="hasOne"
 REFRENCES_MANY="refrencesMany"
-

--- a/utils/help_menus
+++ b/utils/help_menus
@@ -592,6 +592,7 @@ Variables:
   CIVO_CLUSTER_ID=CIVO cluster ID
   CIVO_MASTER_IP=CIVO cluster master IP address
   CIVO_EMAIL_ADDRESS=email address of your CIVO account
+  CIVO_API_KEY=api key of your CIVO account
 
 " 
 

--- a/utils/package_installer
+++ b/utils/package_installer
@@ -277,11 +277,11 @@ check_and_install_jq() {
         echo "jq cli is required"
         echo "installing jq cli..."
         if [ "${OS}" == "mac" ]; then
-            gum spin --title "jq is not installed, now installing jq" --show-output -- brew install jq
+            eval "$(getGumSpinnerOrLogger "jq is not installed, now installing jq") brew install jq"
         elif [ "${OS}" == "gnu" ]; then
             status_log $TYPE_INFO "going to refresh snap"
             sudo snap refresh >/dev/null 2>&1
-            gum spin --title "jq is not installed, now installing jq" --show-output -- sudo wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x jq-linux64 && sudo mv jq-linux64 /usr/local/bin/jq
+            eval "$(getGumSpinnerOrLogger "jq is not installed, now installing jq") sudo wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && sudo chmod +x jq-linux64 && sudo mv jq-linux64 /usr/local/bin/jq"
         else
             errMsg="Failed to install jq, OS ${OS} not supported at the moment"
             echo $errMsg

--- a/utils/package_installer
+++ b/utils/package_installer
@@ -59,10 +59,10 @@ check_and_install_helm() {
         echo "helm is a prerequisite for this script to run."
         echo "installing helm..."
         if [ $OS == "mac" ]; then 
-            gum spin --title "a prerequisite helm is not installed, now installing helm" --show-output -- brew install helm
+            eval "$(getGumSpinnerOrLogger "a prerequisite helm is not installed, now installing helm") brew install helm"
         elif [ $OS == "gnu" ]; then
             sudo snap refresh >/dev/null 2>&1
-            gum spin --title "a prerequisite helm is not installed, now installing helm" --show-output -- sudo snap install helm --classic
+            eval "$(getGumSpinnerOrLogger "a prerequisite helm is not installed, now installing helm") sudo snap install helm --classic"
         else
             errMsg="Failed to install a prerequisite helm, OS ${OS} not supported at the moment"
             echo $errMsg
@@ -82,10 +82,10 @@ check_and_install_kubectl(){
         echo "kubectl is a prerequisite for this script to run."
         echo "installing kubectl..."
         if [ $OS == "mac" ]; then 
-            gum spin --title "a prerequisite kubectl is not installed, now installing kubectl" --show-output -- brew install kubectl
+            eval "$(getGumSpinnerOrLogger "a prerequisite kubectl is not installed, now installing kubectl") brew install kubectl"
         elif [ $OS == "gnu" ]; then
             sudo snap refresh >/dev/null 2>&1
-            gum spin --title "a prerequisite kubectl is not installed, now installing kubectl" --show-output -- sudo snap install kubectl --classic
+            eval "$(getGumSpinnerOrLogger "a prerequisite kubectl is not installed, now installing kubectl") sudo snap install kubectl --classic"
         else
             errMsg="Failed to install a prerequisite kubectl, OS ${OS} not supported at the moment"
             echo $errMsg
@@ -103,10 +103,10 @@ check_and_install_civo() {
         echo "civo cli is required"
         echo "installing civo cli..."
         if [ $OS == "mac" ]; then 
-            gum spin --title "a prerequisite civo is not installed, now tapping civo" --show-output -- brew tap civo/tools
-            gum spin --title "a prerequisite civo is not installed, now installing civo" --show-output -- brew install civo
+            eval "$(getGumSpinnerOrLogger "a prerequisite civo is not installed, now tapping civo") brew tap civo/tools"
+            eval "$(getGumSpinnerOrLogger "a prerequisite civo is not installed, now installing civo") brew install civo"
         elif [ $OS == "gnu" ]; then
-            gum spin --title "a prerequisite civo is not installed, now installing civo" --show-output -- curl -sL https://civo.com/get | sh
+            eval "$(getGumSpinnerOrLogger "a prerequisite civo is not installed, now installing civo") curl -sL https://civo.com/get | sh"
             status_log $TYPE_INFO "going to move /tmp/civo /usr/local/bin/civo this might take some time"
             sudo mv /tmp/civo /usr/local/bin/civo
         else
@@ -127,9 +127,9 @@ check_and_install_minikube() {
         echo "minikube cli is required"
         echo "installing minikube cli..."
         if [ "${OS}" == "mac" ]; then
-            gum spin --title "minikube is not installed, now installing minikube" --show-output --  brew install minikube
+            eval "$(getGumSpinnerOrLogger "a prerequisite minikube is not installed, now installing minikube") brew install minikube"
         elif [ "${OS}" == "gnu" ]; then
-            gum spin --title "minikube is not installed, now installing minikube" --show-output --  wget https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+            eval "$(getGumSpinnerOrLogger "a prerequisite minikube is not installed, now installing minikube") wget https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64"
             chmod +x minikube-linux-amd64
             sudo mv minikube-linux-amd64 /usr/local/bin/minikube
         else
@@ -151,10 +151,10 @@ check_and_install_kbcli() {
         echo "kbcli cli is required"
         echo "installing kbcli cli..."
         if [ "${OS}" == "mac" ]; then
-            gum spin --title "a prerequisite kbcli is not installed, now tapping kbcli" --show-output -- brew tap apecloud/tap
-            gum spin --title "a prerequisite kbcli is not installed, now installing kbcli" --show-output -- brew install kbcli
+            eval "$(getGumSpinnerOrLogger "a prerequisite kbcli is not installed, now tapping kbcli") brew tap apecloud/tap"
+            eval "$(getGumSpinnerOrLogger "a prerequisite kbcli is not installed, now installing kbcli") brew install kbcli"
          elif [ "${OS}" == "gnu" ]; then
-            gum spin --title "a prerequisite kbcli is not installed, now installing kbcli" --show-output -- curl -fsSL https://kubeblocks.io/installer/install_cli.sh | bash 
+            eval "$(getGumSpinnerOrLogger "a prerequisite kbcli is not installed, now installing kbcli") curl -fsSL https://kubeblocks.io/installer/install_cli.sh | bash "
         else
             errMsg="Failed to install kbcli, OS ${OS} not supported at the moment"
             echo $errMsg
@@ -171,7 +171,7 @@ check_and_install_kubeblocks() {
 
     # checks for checking and installing kubeblocks
     if ! kbcli cluster list 2>/dev/null || ! kbcli kubeblocks status; then
-        gum spin --title "installing kubeblocks" --show-output -- kbcli kubeblocks install --set image.registry="docker.io"
+        eval "$(getGumSpinnerOrLogger "installing kubeblocks") kbcli kubeblocks install --set image.registry=\"docker.io\""
     fi
    
     extract_kubeblocks_cli_version
@@ -185,12 +185,12 @@ check_and_install_asciidoc() {
         echo "asciidoctor cli is required"
         echo "installing asciidoctor cli..."
         if [ "${OS}" == "mac" ]; then
-            gum spin --title "asciidoctor is not installed, now installing asciidoctor" --show-output -- brew install asciidoctor
+            eval "$(getGumSpinnerOrLogger "asciidoctor is not installed, now installing asciidoctor") brew install asciidoctor"
         elif [ "${OS}" == "gnu" ]; then
             status_log $TYPE_INFO "going to refresh snap"
             sudo snap refresh 2>&1
-            gum spin --title "ruby is not installed, now installing ruby" --show-output -- sudo snap install ruby --classic
-            gum spin --title "asciidoctor is not installed, now installing asciidoctor" --show-output -- gem install asciidoctor
+            eval "$(getGumSpinnerOrLogger "ruby is not installed, now installing ruby") sudo snap install ruby --classic"
+            eval "$(getGumSpinnerOrLogger "asciidoctor is not installed, now installing asciidoctor") gem install asciidoctor"
             exe_file_path=$(gem which asciidoctor)
             extracted_version=$(echo "$string" | awk -F '/' '{print $6}')
             asciidoc_template_path="~/.gem/gems/{}/bin"
@@ -213,11 +213,11 @@ check_and_install_git() {
         echo "git cli is required"
         echo "installing git cli..."
         if [ "${OS}" == "mac" ]; then
-            gum spin --title "git is not installed, now installing git" --show-output -- brew install git
+            eval "$(getGumSpinnerOrLogger "git is not installed, now installing git") brew install git"
         elif [ "${OS}" == "gnu" ]; then
             status_log $TYPE_INFO "going to update apt"
             sudo apt update 2>&1
-            gum spin --title "git is not installed, now installing git" --show-output -- sudo apt install git
+            eval "$(getGumSpinnerOrLogger "git is not installed, now installing git") sudo apt install git"
         else
             errMsg="Failed to install git, OS ${OS} not supported at the moment"
             echo $errMsg
@@ -237,11 +237,11 @@ check_and_install_yq() {
         echo "yq cli is required"
         echo "installing yq cli..."
         if [ "${OS}" == "mac" ]; then
-            gum spin --title "yq is not installed, now installing yq" --show-output -- brew install yq
+            eval "$(getGumSpinnerOrLogger "yq is not installed, now installing yq") brew install yq"
         elif [ "${OS}" == "gnu" ]; then
             status_log $TYPE_INFO "going to refresh snap"
             sudo snap refresh >/dev/null 2>&1
-            gum spin --title "yq is not installed, now installing yq" --show-output -- sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+            eval "$(getGumSpinnerOrLogger "yq is not installed, now installing yq") sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq"
         else
             errMsg="Failed to install yq, OS ${OS} not supported at the moment"
             echo $errMsg
@@ -263,8 +263,8 @@ check_and_install_gettext() {
     if ! gettext --version  >/dev/null 2>&1; then
         echo "gettext cli is required"
         echo "installing gettext cli..."
-        gum spin --title "gettext is not installed, now installing gettext" --show-output -- brew install gettext
-        gum spin --title "linking gettext" --show-output -- brew link --force gettext
+        eval "$(getGumSpinnerOrLogger "gettext is not installed, now installing gettext") brew install gettext"
+        eval "$(getGumSpinnerOrLogger "linking gettext") brew link --force gettext"
     fi
     
 }


### PR DESCRIPTION
**Description**

Resolved GC-80 and GC-81 because GC-81 was a subset of GC-80

Testcases
`docker run --rm --env CIVO_API_KEY=F4ql1F7ENpOgMOi7HRK8EqcWWbkd5p4qMoOqZNIjKWgF4nntK1 test/t1 bash -c './home/linuxbrew/code/grpl c i  --params --TARGET_PLATFORM=CIVO --CIVO_REGION=fra1 --CIVO_CLUSTER=zahid-cli --CIVO_EMAIL_ADDRESS=info@grapple-solutions.com --GRAPPLE_VERSION=0.2.4 --AUTO_CONFIRM=true'`

`docker run --rm --env CIVO_API_KEY=F4ql1F7ENpOgMOi7HRK8EqcWWbkd5p4qMoOqZNIjKWgF4nntK1 test/t1 bash -c './home/linuxbrew/code/grpl c i  --params --TARGET_PLATFORM=CIVO --CIVO_REGION=fra1 --CIVO_CLUSTER=zahid-cli --CIVO_EMAIL_ADDRESS=info@grapple-solutions.com --GRAPPLE_VERSION=0.2.4 --AUTO_CONFIRM=true'`