### PR TITLE
Gc 78 show error of c i failure

### DIFF
--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -271,8 +271,8 @@ helm_deploy() {
       status_log $TYPE_INFO "logged out of public.ecr.aws/${awsregistry} registry"
       helm_deploy $i
     else 
-      status_log $TYPE_ERROR "${i} Failed to Installed"
-      echo "${i} Failed to Installed due to following error"
+      echo "${i} Failed to Installed"
+      status_log $TYPE_ERROR "${i} Failed to Installed due to following error"
       eval "$(getGumSpinnerOrLogger "Installing ${i} component") helm upgrade --install $i oci://public.ecr.aws/${awsregistry}/$i -n ${NS} ${version} --create-namespace -f /tmp/values-override.yaml $values_yaml_file_names"  >&2    
       exit 1
     fi

--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -271,8 +271,9 @@ helm_deploy() {
       status_log $TYPE_INFO "logged out of public.ecr.aws/${awsregistry} registry"
       helm_deploy $i
     else 
-      echo "${i} Failed to Installed"
       status_log $TYPE_ERROR "${i} Failed to Installed"
+      echo "${i} Failed to Installed due to following error"
+      eval "$(getGumSpinnerOrLogger "Installing ${i} component") helm upgrade --install $i oci://public.ecr.aws/${awsregistry}/$i -n ${NS} ${version} --create-namespace -f /tmp/values-override.yaml $values_yaml_file_names"  >&2    
       exit 1
     fi
   fi


### PR DESCRIPTION
**Description**
- Successfuly showed c i failure error on cli
- unable to log it in file.
  **Reason**
  when following command : eval "$(getGumSpinnerOrLogger "Installing ${i} component") helm upgrade --install $i oci://public.ecr.aws/${awsregistry}/$i -n ${NS} ${version} --create-namespace -f /tmp/values-override.yaml $values_yaml_file_names"
  fails it breaks the execution, which make us unable to log it into the file. I only way I was able to log it on cli was that I redirected the output of its command to stderr using **>&2 **

**Testcase**
![Screenshot from 2024-07-29 09-03-50](https://github.com/user-attachments/assets/20eb4418-a5a2-4acf-a0ea-8d7c95134522)
