### PR TITLE
Gc 104 fixed lic issues

### DIFF
--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -538,8 +538,6 @@ fi
 
 license=$(kubectl get secret -n grpl-system grsf-config -o jsonpath="{.data.LIC}" 2>/dev/null | base64 --decode 2>/dev/null)
 
-status_log $TYPE_INFO "license: ${license}"
-
 if [[ $? -ne 0 ]]; then
     GRAPPLE_LICENSE="free"
 elif [[ -z $license ]]; then

--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -536,7 +536,7 @@ else
 fi
 
 
-if kubectl get secret -n grpl-system grsf-config -o jsonpath="{.data.LIC}" | base64 --decode 2>&1 > /dev/null ; then
+if kubectl get secret -n grpl-system grsf-config -o jsonpath="{.data.LIC}" | base64 --decode >/dev/null 2>&1 ; then
     GRAPPLE_LICENSE=$(kubectl get secret -n grpl-system grsf-config -o jsonpath="{.data.LIC}" | base64 --decode)
 elif [[ -z $license ]]; then
     GRAPPLE_LICENSE="free"

--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -536,14 +536,10 @@ else
 fi
 
 
-license=$(eval "$(getGumSpinnerOrLogger "Fetching LIC (License)") kubectl get secret -n grpl-system grsf-config -o jsonpath="{.data.LIC}" | base64 --decode")
-
-if [[ $? -ne 0 ]]; then
-    GRAPPLE_LICENSE="free"
+if kubectl get secret -n grpl-system grsf-config -o jsonpath="{.data.LIC}" | base64 --decode 2>&1 > /dev/null ; then
+    GRAPPLE_LICENSE=$(kubectl get secret -n grpl-system grsf-config -o jsonpath="{.data.LIC}" | base64 --decode)
 elif [[ -z $license ]]; then
     GRAPPLE_LICENSE="free"
-else
-    GRAPPLE_LICENSE=$license
 fi
 
 

--- a/commands/cluster_commands/install
+++ b/commands/cluster_commands/install
@@ -536,10 +536,16 @@ else
 fi
 
 
-if kubectl get secret -n grpl-system grsf-config -o jsonpath="{.data.LIC}" | base64 --decode >/dev/null 2>&1 ; then
-    GRAPPLE_LICENSE=$(kubectl get secret -n grpl-system grsf-config -o jsonpath="{.data.LIC}" | base64 --decode)
+license=$(kubectl get secret -n grpl-system grsf-config -o jsonpath="{.data.LIC}" 2>/dev/null | base64 --decode 2>/dev/null)
+
+status_log $TYPE_INFO "license: ${license}"
+
+if [[ $? -ne 0 ]]; then
+    GRAPPLE_LICENSE="free"
 elif [[ -z $license ]]; then
     GRAPPLE_LICENSE="free"
+else
+    GRAPPLE_LICENSE=$license
 fi
 
 


### PR DESCRIPTION
Testcases

1. Build an image using fixed code
![Screenshot from 2024-10-10 19-29-23](https://github.com/user-attachments/assets/96285033-78d5-4a6d-9097-6fa74ed586d6)

2. Then used that image to run a container, and inside the container I ran grpl c i
 Here you can see we don't get any error. and First time the GRAPPLE_LICENSE=free
![Screenshot from 2024-10-10 19-29-23](https://github.com/user-attachments/assets/4a69750f-de48-4ee2-b694-7b225d8a97e7)

3. Then I patched the LIC value to "pro", and re-ran grpl c i
here you can see that now GRAPPLE_LICENSE=pro
![Screenshot from 2024-10-10 19-44-51](https://github.com/user-attachments/assets/0f74dd72-1943-49be-a64d-2325f6f3b559)

